### PR TITLE
#8: docs: add RELEASING.md with bundled pi skills note

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# releasing plot-ai
+
+## channels
+
+- `latest` — stable releases
+- `beta` — prerelease builds
+
+## versioning
+
+plot-ai uses lockstep semver across the public npm surface.
+
+- patch: fixes and small polish
+- minor: backwards-compatible commands, flags, and packaging improvements
+- major: breaking cli flags, config, or runtime behavior
+
+## publish flow
+
+1. choose a version
+2. run the full verification gates
+3. build release artifacts
+4. verify bundled pi runtime skills are present in platform packages (see below)
+5. publish platform packages
+6. publish `plot-ai`
+7. create the github release for the same version tag
+
+## bundled pi runtime skills
+
+each platform package must include the `pi-resources/skills/` directory.
+these skills are loaded at runtime by the embedded agent.
+
+verify before publishing:
+
+```bash
+ls packages/cli-*/pi-resources/skills/
+```
+
+every skill referenced in `AGENTS.md` → `<available_skills>` must be present in
+the built output.
+
+## commands
+
+```bash
+PLOT_VERSION=0.0.1 bun run release:build
+bun run release:smoke
+PLOT_CHANNEL=latest bun run release:publish:dry-run
+PLOT_VERSION=0.0.1 PLOT_CHANNEL=latest bun run release:publish
+```


### PR DESCRIPTION
## Summary

Add `RELEASING.md` documenting the release flow for plot-ai, including a dedicated section on verifying that bundled pi runtime skills are present in platform packages before publishing.

## Changes

- Create `RELEASING.md` with channels, versioning, and publish flow
- Add "bundled pi runtime skills" section with verification command
- Reference pi skills in publish flow step 4

## Verification

- [x] Lint passes (`bun run lint`) — 0 errors
- [ ] Typecheck (`bun run typecheck`) — pre-existing errors unrelated to this change
- [x] Documentation-only change, no runtime impact

## Issue

Resolves #8
