### PR TITLE
#10: document runtime observability dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ server ──> rpc + sse ──> tui
                   └───> web dashboard
 ```
 
+## runtime observability
+
+both dashboards surface live runtime diagnostics.
+
+**web dashboard** — the runtime panel shows queue depth, peak depth, and backpressure status. it also displays retry reason mix (why runs were retried) and worker stop/exit reasons so you can see at a glance what is failing and why.
+
+**tui** — the terminal dashboard includes a runtime observability summary with the same key metrics: queue pressure, retry reasons, and worker lifecycle events.
+
 ## requirements
 
 - bun 1.3.5


### PR DESCRIPTION
## Summary

adds a short runtime observability section to README.md describing the web dashboard runtime panel and tui observability summary.

## Changes

- added "runtime observability" section to README between "runtime shape" and "requirements"
- documents web dashboard: queue depth, peak depth, backpressure, retry reason mix, worker stop/exit reasons
- documents tui: runtime observability summary with same key metrics

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] Diff is 8 lines added, docs-only

## Issue

Resolves #10
