### PR TITLE
#16: verify realtime SSE dashboard — fix StatusDot reconnecting style

### DIFF
--- a/packages/sdk/src/sse.test.ts
+++ b/packages/sdk/src/sse.test.ts
@@ -114,6 +114,50 @@ describe("connectSse", () => {
 		expect(timers).toHaveLength(1);
 	});
 
+	test("reconnect timer fires and triggers a new connection", async () => {
+		let fetchCount = 0;
+		const timers: TimerHandler[] = [];
+		globalThis.setTimeout = ((handler: TimerHandler) => {
+			timers.push(handler);
+			return timers.length as unknown as ReturnType<typeof setTimeout>;
+		}) as typeof setTimeout;
+		globalThis.clearTimeout = ((_timer) => undefined) as typeof clearTimeout;
+		console.warn = () => {};
+		globalThis.fetch = (async (..._args: Parameters<typeof fetch>) => {
+			fetchCount += 1;
+			return makeResponse([]);
+		}) as typeof fetch;
+
+		const statuses: SseStatus[] = [];
+		const connection = connectSse(
+			"http://example.test/events",
+			() => {},
+			(status) => {
+				statuses.push(status);
+			},
+		);
+
+		await Bun.sleep(25);
+		expect(fetchCount).toBe(1);
+
+		timers[0]!();
+		await Bun.sleep(25);
+		expect(fetchCount).toBe(2);
+
+		connection.close();
+		expect(statuses).toEqual([
+			"connecting",
+			"connected",
+			"disconnected",
+			"reconnecting",
+			"connecting",
+			"connected",
+			"disconnected",
+			"reconnecting",
+			"disconnected",
+		]);
+	});
+
 	test("close clears a pending reconnect and prevents another fetch", async () => {
 		const timers: TimerHandler[] = [];
 		const cleared: Array<ReturnType<typeof setTimeout>> = [];

--- a/packages/web/src/components/dashboard/status-dot.tsx
+++ b/packages/web/src/components/dashboard/status-dot.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 const styles: Record<string, string> = {
 	connected: "bg-success",
 	connecting: "bg-warning animate-pulse",
+	reconnecting: "bg-warning animate-pulse",
 	disconnected: "bg-destructive",
 };
 


### PR DESCRIPTION
## Summary

Fix missing `reconnecting` style in StatusDot and add SSE reconnect cycle test to verify the full realtime dashboard SSE implementation.

## Changes

- Add `reconnecting` entry to `StatusDot` styles map (was missing — dot rendered with no background color during reconnect)
- Add SDK test verifying full reconnect cycle: timer fires, second fetch triggers, complete status sequence validated

## Verification

- [x] Typecheck passes (`bun run typecheck`) — 4/4 packages
- [x] Lint passes (`bun run lint`) — 0 errors
- [x] Tests pass (`bun test packages/sdk/src/sse.test.ts`) — 4/4

## Issue

Resolves #16
