### PR TITLE
#29: add keyboard shortcut to toggle ops panel

### DIFF
--- a/packages/web/src/components/dashboard/header.tsx
+++ b/packages/web/src/components/dashboard/header.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
-import { RefreshCwIcon } from "lucide-react";
+import { useCallback, useEffect } from "react";
+import { ActivityIcon, RefreshCwIcon } from "lucide-react";
 import { StatusDot } from "./status-dot";
+import { useDashboard } from "./root";
 import { useRuntimeState, useTriggerRefresh } from "@/lib/hooks";
 import { useEventStream } from "@/lib/use-event-stream";
 import { Button } from "@/components/ui/button";
@@ -15,10 +16,27 @@ export function Header() {
 	const { data: snapshot } = useRuntimeState();
 	const refresh = useTriggerRefresh();
 	const { status: sseStatus } = useEventStream();
+	const { actions } = useDashboard();
 	const counts = snapshot?.counts;
 	const handleRefresh = useCallback(() => {
 		refresh.mutate();
 	}, [refresh]);
+
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (
+				e.key === "o" &&
+				e.shiftKey &&
+				(e.metaKey || e.ctrlKey) &&
+				!e.altKey
+			) {
+				e.preventDefault();
+				actions.toggleOps();
+			}
+		}
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [actions]);
 
 	return (
 		<header className="header-surface">
@@ -41,6 +59,13 @@ export function Header() {
 							<TooltipPopup>stream {sseStatus}</TooltipPopup>
 						</Tooltip>
 					</TooltipProvider>
+					<Button
+						variant="ghost"
+						size="icon-xs"
+						onClick={actions.toggleOps}
+					>
+						<ActivityIcon />
+					</Button>
 					<Button variant="ghost" size="icon-xs" onClick={handleRefresh}>
 						<RefreshCwIcon />
 					</Button>

--- a/packages/web/src/components/dashboard/ops-panel.tsx
+++ b/packages/web/src/components/dashboard/ops-panel.tsx
@@ -1,0 +1,13 @@
+import { useDashboard } from "./root";
+import { ObservabilitySection } from "./observability-section";
+
+export function OpsPanel() {
+	const { state } = useDashboard();
+	if (!state.opsOpen) return null;
+
+	return (
+		<div className="view-shell">
+			<ObservabilitySection />
+		</div>
+	);
+}

--- a/packages/web/src/components/dashboard/root.tsx
+++ b/packages/web/src/components/dashboard/root.tsx
@@ -1,11 +1,20 @@
-import { use, createContext, useMemo, useState, type ReactNode } from "react";
+import {
+	use,
+	createContext,
+	useCallback,
+	useMemo,
+	useState,
+	type ReactNode,
+} from "react";
 
 export interface DashboardState {
 	focusedIssueId: string | null;
+	opsOpen: boolean;
 }
 
 export interface DashboardActions {
 	focusIssue: (id: string | null) => void;
+	toggleOps: () => void;
 }
 
 export interface DashboardContextValue {
@@ -26,13 +35,16 @@ export function useDashboard(): DashboardContextValue {
 
 export function Root({ children }: { children: ReactNode }) {
 	const [focusedIssueId, setFocusedIssueId] = useState<string | null>(null);
+	const [opsOpen, setOpsOpen] = useState(false);
+
+	const toggleOps = useCallback(() => setOpsOpen((prev) => !prev), []);
 
 	const value = useMemo(
 		() => ({
-			state: { focusedIssueId },
-			actions: { focusIssue: setFocusedIssueId },
+			state: { focusedIssueId, opsOpen },
+			actions: { focusIssue: setFocusedIssueId, toggleOps },
 		}),
-		[focusedIssueId],
+		[focusedIssueId, opsOpen, toggleOps],
 	);
 
 	return (

--- a/packages/web/src/routes/index.tsx
+++ b/packages/web/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createRoute } from "@tanstack/react-router";
 import { Route as rootRoute } from "./__root";
 import { Dashboard } from "@/components/dashboard";
+import { OpsPanel } from "@/components/dashboard/ops-panel";
 
 /**
  * keeps the default dashboard honest: orientation first, inspection second.
@@ -13,6 +14,7 @@ function DashboardPage() {
 	return (
 		<Dashboard.Root>
 			<Dashboard.Header />
+			<OpsPanel />
 			<div className="view-shell">
 				<Dashboard.WorkQueue />
 			</div>


### PR DESCRIPTION
## Summary

Adds keyboard shortcut `Cmd+Shift+O` (Mac) / `Ctrl+Shift+O` (other) to toggle the ops panel (runtime observability section) on the dashboard page. Also adds an Activity icon button in the header for mouse-based toggling.

## Changes

- Added `opsOpen` state and `toggleOps` action to Dashboard context (`root.tsx`)
- Added Activity icon button in header to toggle ops panel (`header.tsx`)
- Added `useEffect` keyboard shortcut listener for `Cmd+Shift+O` / `Ctrl+Shift+O` (`header.tsx`)
- Created `OpsPanel` component that conditionally renders `ObservabilitySection` (`ops-panel.tsx`)
- Wired `OpsPanel` into dashboard page layout (`routes/index.tsx`)

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] Shortcut uses `e.preventDefault()` to avoid browser conflicts
- [x] Listener attached to `window` so it works regardless of focus

## Issue

Resolves #29
