### PR TITLE
#31: add aria-label to refresh button in dashboard header

### DIFF
--- a/packages/web/src/components/dashboard/header.tsx
+++ b/packages/web/src/components/dashboard/header.tsx
@@ -41,7 +41,7 @@ export function Header() {
 							<TooltipPopup>stream {sseStatus}</TooltipPopup>
 						</Tooltip>
 					</TooltipProvider>
-					<Button variant="ghost" size="icon-xs" onClick={handleRefresh}>
+					<Button variant="ghost" size="icon-xs" aria-label="refresh" onClick={handleRefresh}>
 						<RefreshCwIcon />
 					</Button>
 				</div>


### PR DESCRIPTION
## Summary

Add `aria-label="refresh"` to the refresh button in the dashboard header for accessibility.

## Changes

- Add `aria-label="refresh"` to Button wrapping RefreshCwIcon in `packages/web/src/components/dashboard/header.tsx`

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

## Issue

Resolves #31
