### PR TITLE
#33: add title attribute to status dot in header

### DIFF
--- a/packages/web/src/components/dashboard/status-dot.tsx
+++ b/packages/web/src/components/dashboard/status-dot.tsx
@@ -15,6 +15,7 @@ export function StatusDot({ status, className }: StatusDotProps) {
 	return (
 		<span
 			className={cn("size-1.5 rounded-full", styles[status], className)}
+			title={status}
 			aria-label={status}
 		/>
 	);


### PR DESCRIPTION
## Summary

Adds a `title` attribute to the StatusDot component so the browser shows a native tooltip with the current status text on hover.

## Changes

- Add `title={status}` to the `<span>` element in `StatusDot`

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

## Issue

Resolves #33
