### PR TITLE
#35: rename ops panel header to runtime

### DIFF
--- a/packages/web/src/components/dashboard/ops-panel.tsx
+++ b/packages/web/src/components/dashboard/ops-panel.tsx
@@ -1,0 +1,16 @@
+import { ObservabilitySection } from "./observability-section";
+import { RetrySection } from "./retry-section";
+
+export function OpsPanel() {
+	return (
+		<div className="ops-panel">
+			<div className="border-b border-border px-4 py-2">
+				<span className="type-title">runtime</span>
+			</div>
+			<div className="flex-1 overflow-y-auto p-4 space-y-6">
+				<RetrySection />
+				<ObservabilitySection />
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds the ops panel component with header text "runtime" instead of "ops" to better describe the panel's runtime observability purpose.

## Changes

- Add `ops-panel.tsx` with header text set to "runtime"

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

## Issue

Resolves #35
