### PR TITLE
#37: add phase-label crossfade and stick-to-bottom scroll

### DIFF
--- a/packages/web/src/components/dashboard/agent-card.tsx
+++ b/packages/web/src/components/dashboard/agent-card.tsx
@@ -6,6 +6,7 @@ import { statusLabel, statusVariant, isActiveState } from "./status";
 import { timeAgo as sharedTimeAgo } from "@plot/sdk";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { PhaseLabel } from "./phase-label";
 
 interface WorkRowProps {
 	entry: RunningEntry;
@@ -39,7 +40,7 @@ export function WorkRow({ entry, isSelected }: WorkRowProps) {
 				<div className="cluster-shell">
 					<span className="type-title truncate">{entry.issueIdentifier}</span>
 					<Badge variant={statusVariant(entry.state)} size="sm">
-						{statusLabel(entry.state)}
+						<PhaseLabel label={statusLabel(entry.state)} />
 					</Badge>
 				</div>
 			</div>

--- a/packages/web/src/components/dashboard/agent-detail.tsx
+++ b/packages/web/src/components/dashboard/agent-detail.tsx
@@ -1,11 +1,14 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { DateTime } from "effect";
 import { Streamdown } from "streamdown";
 import "streamdown/styles.css";
+import type { AgentRuntimeEvent } from "@plot/sdk";
 import { useDashboard } from "./root";
+import { PhaseLabel } from "./phase-label";
 import { statusLabel, statusVariant } from "./status";
 import { timeAgo as sharedTimeAgo } from "@plot/sdk";
 import { useIssueDetail, useRuntimeState } from "@/lib/hooks";
+import { useStickToBottom } from "@/hooks/use-stick-to-bottom";
 import { Badge } from "@/components/ui/badge";
 import {
 	Sheet,
@@ -19,6 +22,66 @@ import {
 function formatTimeAgo(dt: DateTime.Utc | string): string {
 	if (typeof dt === "string") return sharedTimeAgo(new Date(dt).getTime());
 	return sharedTimeAgo(DateTime.toEpochMillis(dt));
+}
+
+function formatEventTime(dt: DateTime.Utc): string {
+	const d = new Date(Number(DateTime.toEpochMillis(dt)));
+	return d.toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	});
+}
+
+function EventRow({ event }: { event: AgentRuntimeEvent }) {
+	return (
+		<div className="flex items-start gap-2 border-b border-border px-3 py-2 text-xs last:border-b-0">
+			<span className="shrink-0 font-mono text-muted-foreground">
+				{formatEventTime(event.timestamp)}
+			</span>
+			<span className="text-foreground">{event.event}</span>
+			{event.message ? (
+				<span className="min-w-0 truncate text-muted-foreground">
+					{event.message}
+				</span>
+			) : null}
+		</div>
+	);
+}
+
+function EventTail({ events }: { events: ReadonlyArray<AgentRuntimeEvent> }) {
+	const { ref, isAtBottom, scrollToBottom } = useStickToBottom<HTMLDivElement>();
+
+	return (
+		<div className="section-shell">
+			<div className="flex items-center justify-between">
+				<p className="type-meta">event trace</p>
+				{!isAtBottom && (
+					<button
+						type="button"
+						className="text-xs text-muted-foreground hover:text-foreground"
+						onClick={scrollToBottom}
+					>
+						scroll to bottom
+					</button>
+				)}
+			</div>
+			<div ref={ref} className="inset-shell max-h-64 overflow-y-auto">
+				{events.length > 0 ? (
+					events.map((event) => (
+						<EventRow
+							key={`${event.issueId}-${event.event}-${Number(DateTime.toEpochMillis(event.timestamp))}`}
+							event={event}
+						/>
+					))
+				) : (
+					<p className="px-3 py-2 text-xs text-muted-foreground">
+						no events yet
+					</p>
+				)}
+			</div>
+		</div>
+	);
 }
 
 export function WorkDetailSheet() {
@@ -46,6 +109,7 @@ export function WorkDetailSheet() {
 	const lastUpdated = entry?.session.lastEventAt
 		? formatTimeAgo(entry.session.lastEventAt)
 		: null;
+	const events = useMemo(() => detail?.eventTail ?? [], [detail?.eventTail]);
 
 	return (
 		<Sheet onOpenChange={handleOpenChange} open={open}>
@@ -58,7 +122,7 @@ export function WorkDetailSheet() {
 									{entry.issueIdentifier}
 								</SheetTitle>
 								<Badge variant={statusVariant(entry.state)} size="sm">
-									{statusLabel(entry.state)}
+									<PhaseLabel label={statusLabel(entry.state)} />
 								</Badge>
 							</div>
 							<SheetDescription className="type-meta">
@@ -80,6 +144,7 @@ export function WorkDetailSheet() {
 									</p>
 								)}
 							</div>
+							<EventTail events={events} />
 						</SheetPanel>
 					</>
 				) : null}

--- a/packages/web/src/components/dashboard/phase-label.tsx
+++ b/packages/web/src/components/dashboard/phase-label.tsx
@@ -1,0 +1,25 @@
+import { AnimatePresence, motion } from "motion/react";
+
+const spring = { type: "spring" as const, bounce: 0.15, duration: 0.4 };
+const enter = { y: 6, opacity: 0, filter: "blur(3px)" };
+const visible = { y: 0, opacity: 1, filter: "blur(0px)" };
+const leave = { y: -6, opacity: 0, filter: "blur(3px)" };
+
+export function PhaseLabel({ label }: { label: string }) {
+	return (
+		<span className="relative inline-flex overflow-hidden">
+			<AnimatePresence mode="popLayout" initial={false}>
+				<motion.span
+					key={label}
+					initial={enter}
+					animate={visible}
+					exit={leave}
+					transition={spring}
+					className="inline-block"
+				>
+					{label}
+				</motion.span>
+			</AnimatePresence>
+		</span>
+	);
+}

--- a/packages/web/src/hooks/use-stick-to-bottom.ts
+++ b/packages/web/src/hooks/use-stick-to-bottom.ts
@@ -1,0 +1,84 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { animate } from "motion/react";
+
+const THRESHOLD = 30;
+
+export function useStickToBottom<T extends HTMLElement = HTMLDivElement>() {
+	const ref = useRef<T>(null);
+	const [isAtBottom, setIsAtBottom] = useState(true);
+	const userScrolledRef = useRef(false);
+	const animationRef = useRef<ReturnType<typeof animate> | null>(null);
+
+	const checkAtBottom = useCallback((el: T) => {
+		const atBottom =
+			el.scrollHeight - el.scrollTop - el.clientHeight < THRESHOLD;
+		setIsAtBottom(atBottom);
+		return atBottom;
+	}, []);
+
+	const scrollToBottom = useCallback(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		animationRef.current?.stop();
+		const from = el.scrollTop;
+		const to = el.scrollHeight - el.clientHeight;
+		if (Math.abs(to - from) < 1) return;
+
+		userScrolledRef.current = false;
+		animationRef.current = animate(from, to, {
+			type: "spring",
+			bounce: 0.05,
+			duration: 0.5,
+			onUpdate: (v) => {
+				el.scrollTop = v;
+			},
+			onComplete: () => {
+				setIsAtBottom(true);
+			},
+		});
+	}, []);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		const handleScroll = () => {
+			if (animationRef.current) return;
+			checkAtBottom(el);
+		};
+
+		const handleWheel = () => {
+			userScrolledRef.current = true;
+			animationRef.current?.stop();
+			animationRef.current = null;
+		};
+
+		el.addEventListener("scroll", handleScroll, { passive: true });
+		el.addEventListener("wheel", handleWheel, { passive: true });
+		el.addEventListener("touchmove", handleWheel, { passive: true });
+
+		return () => {
+			el.removeEventListener("scroll", handleScroll);
+			el.removeEventListener("wheel", handleWheel);
+			el.removeEventListener("touchmove", handleWheel);
+			animationRef.current?.stop();
+		};
+	}, [checkAtBottom]);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		const observer = new MutationObserver(() => {
+			if (!userScrolledRef.current && isAtBottom) {
+				scrollToBottom();
+			}
+		});
+
+		observer.observe(el, { childList: true, subtree: true });
+		return () => observer.disconnect();
+	}, [isAtBottom, scrollToBottom]);
+
+	return { ref, isAtBottom, scrollToBottom };
+}


### PR DESCRIPTION
## Summary

Adds phase-label crossfade animation and stick-to-bottom auto-scroll for the dashboard's work rail and trace viewer.

## Changes

- `PhaseLabel` component — uses motion/react `AnimatePresence` with blur+slide spring animation for smooth state text transitions (thinking → reading → working etc.)
- `useStickToBottom` hook — spring-based auto-scroll with user scroll-up cancel and MutationObserver re-follow
- `EventTail` section in `WorkDetailSheet` — displays event trace from `IssueDetail.eventTail` with stick-to-bottom behavior
- Integrated `PhaseLabel` into `WorkRow` and `WorkDetailSheet` badges

## Verification

- [x] Typecheck passes (`bun run typecheck`) — 4/4 packages
- [x] Lint passes (`bun run lint`) — 0 warnings, 0 errors
- [ ] Visual verification (manual e2e — requires running instance)

## Issue

Resolves #37
