### PR TITLE
#47: clear existing web lint warnings in trace/dashboard views

### DIFF
--- a/packages/web/src/components/dashboard/root.tsx
+++ b/packages/web/src/components/dashboard/root.tsx
@@ -42,8 +42,8 @@ export function Root({ children }: { children: ReactNode }) {
   const [focusedIssueId, setFocusedIssueId] = useState<string | null>(null);
   const [opsOpen, setOpsOpen] = useState(false);
   const snapshot = useRuntimeSnapshot();
-  const running = snapshot?.running ?? [];
-  const retrying = snapshot?.retrying ?? [];
+  const running = useMemo(() => snapshot?.running ?? [], [snapshot?.running]);
+  const retrying = useMemo(() => snapshot?.retrying ?? [], [snapshot?.retrying]);
 
   const toggleOps = useCallback(() => setOpsOpen((prev) => !prev), []);
 

--- a/packages/web/src/components/trace-viewer/detail-pane.tsx
+++ b/packages/web/src/components/trace-viewer/detail-pane.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { DateTime } from "effect";
 import type { AgentEventType, AgentRuntimeEvent } from "@plot/sdk";
 import { useTraceViewer } from "./root";
@@ -90,6 +90,7 @@ function collectFields(event: AgentRuntimeEvent): TreeField[] {
 export function DetailPane() {
   const { state } = useTraceViewer();
   const [showRaw, setShowRaw] = useState(false);
+  const toggleRaw = useCallback(() => setShowRaw((v) => !v), []);
 
   if (!state.selectedEvent) {
     return (
@@ -113,7 +114,7 @@ export function DetailPane() {
         <button
           type="button"
           className="type-meta hover:text-foreground"
-          onClick={() => setShowRaw((v) => !v)}
+          onClick={toggleRaw}
           aria-label="toggle raw json"
         >
           {"{}"}

--- a/packages/web/src/components/trace-viewer/event-list.tsx
+++ b/packages/web/src/components/trace-viewer/event-list.tsx
@@ -49,8 +49,8 @@ function RawEventList() {
 
   return (
     <>
-      {filteredEvents.map((event, i) => (
-        <EventRow key={`${Number(event.timestamp)}-${i}`} event={event} />
+      {filteredEvents.map((event) => (
+        <EventRow key={`${event.event}-${Number(event.timestamp)}-${event.toolCallId ?? ""}`} event={event} />
       ))}
     </>
   );

--- a/packages/web/src/components/trace-viewer/grouped-event-list.tsx
+++ b/packages/web/src/components/trace-viewer/grouped-event-list.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { DateTime } from "effect";
 import { cn } from "@/lib/utils";
 import { useTraceViewer } from "./root";
@@ -60,9 +60,53 @@ function PulseDot() {
   );
 }
 
-function TurnSection({ turn }: { turn: TurnGroup }) {
+function ToolCallRow({
+  tc,
+  turn,
+  connector,
+}: {
+  tc: ToolCallGroup;
+  turn: TurnGroup;
+  connector: string;
+}) {
   const { actions } = useTraceViewer();
+  const color = toolColorMap[tc.toolName] ?? "text-zinc-400";
+  const handleClick = useCallback(
+    () => actions.selectEvent(tc.events[tc.events.length - 1] ?? null),
+    [actions, tc.events],
+  );
 
+  return (
+    <button
+      type="button"
+      className={cn(
+        "trace-tool-row flex w-full items-center gap-2 px-3 py-1 pl-6 type-body hover:bg-accent/20 cursor-pointer text-left",
+        tc.isError && "text-red-400/80",
+      )}
+      onClick={handleClick}
+    >
+      <span className="w-4 shrink-0 type-meta">{connector}</span>
+      <span className={cn("w-[72px] shrink-0 truncate", color)}>{tc.toolName}</span>
+      <span className="min-w-0 flex-1 truncate text-foreground">
+        {tc.summary ? truncate(tc.summary, 80) : ""}
+      </span>
+      <span className="shrink-0 type-meta tabular-nums">
+        {formatRelative(turn.startedAt, tc.startedAt)}
+      </span>
+      <span className="w-14 shrink-0 text-right type-meta tabular-nums">
+        {tc.isActive ? (
+          <PulseDot />
+        ) : tc.durationMs != null ? (
+          formatDuration(tc.durationMs)
+        ) : (
+          ""
+        )}
+      </span>
+    </button>
+  );
+}
+
+function TurnSection({ turn }: { turn: TurnGroup }) {
   const items: Array<
     { kind: "tool"; tc: ToolCallGroup } | { kind: "notification"; message: string }
   > = [];
@@ -95,40 +139,14 @@ function TurnSection({ turn }: { turn: TurnGroup }) {
 
         if (item.kind === "tool") {
           const { tc } = item;
-          const color = toolColorMap[tc.toolName] ?? "text-zinc-400";
+          const key = tc.toolCallId ?? `${tc.toolName}-${Number(DateTime.toEpochMillis(tc.startedAt))}`;
           return (
-            <button
-              key={tc.toolCallId ?? `tc-${i}`}
-              type="button"
-              className={cn(
-                "trace-tool-row flex w-full items-center gap-2 px-3 py-1 pl-6 type-body hover:bg-accent/20 cursor-pointer text-left",
-                tc.isError && "text-red-400/80",
-              )}
-              onClick={() => actions.selectEvent(tc.events[tc.events.length - 1] ?? null)}
-            >
-              <span className="w-4 shrink-0 type-meta">{connector}</span>
-              <span className={cn("w-[72px] shrink-0 truncate", color)}>{tc.toolName}</span>
-              <span className="min-w-0 flex-1 truncate text-foreground">
-                {tc.summary ? truncate(tc.summary, 80) : ""}
-              </span>
-              <span className="shrink-0 type-meta tabular-nums">
-                {formatRelative(turn.startedAt, tc.startedAt)}
-              </span>
-              <span className="w-14 shrink-0 text-right type-meta tabular-nums">
-                {tc.isActive ? (
-                  <PulseDot />
-                ) : tc.durationMs != null ? (
-                  formatDuration(tc.durationMs)
-                ) : (
-                  ""
-                )}
-              </span>
-            </button>
+            <ToolCallRow key={key} tc={tc} turn={turn} connector={connector} />
           );
         }
 
         return (
-          <div key={`notif-${i}`} className="flex items-center gap-2 px-3 py-1 pl-6 type-body">
+          <div key={`notif-${item.message}`} className="flex items-center gap-2 px-3 py-1 pl-6 type-body">
             <span className="w-4 shrink-0 type-meta">{connector}</span>
             <span className="w-[72px] shrink-0 text-muted-foreground">··</span>
             <span className="min-w-0 flex-1 truncate text-muted-foreground">
@@ -147,8 +165,8 @@ function UngroupedEvents({ section }: { section: UngroupedSection }) {
   return (
     <div>
       <div className="px-3 py-1 type-meta">{label}</div>
-      {section.events.map((ev, i) => (
-        <div key={`${section.kind}-${i}`} className="flex items-center gap-2 px-3 py-1 type-meta">
+      {section.events.map((ev) => (
+        <div key={`${section.kind}-${ev.event}-${Number(DateTime.toEpochMillis(ev.timestamp))}`} className="flex items-center gap-2 px-3 py-1 type-meta">
           <span className="shrink-0 tabular-nums">{formatTimestamp(ev.timestamp)}</span>
           <span className="w-[72px] shrink-0 truncate">{ev.event}</span>
           {ev.message && (


### PR DESCRIPTION
## Summary

Clears all 7 existing lint warnings in the web dashboard's trace viewer and dashboard root components.

## Changes

- memoize `setShowRaw` toggle callback in `detail-pane.tsx` via `useCallback`
- extract `ToolCallRow` component from `grouped-event-list.tsx` to eliminate inline `onClick` handler
- replace array-index keys with stable data-derived keys across `grouped-event-list.tsx` and `event-list.tsx`
- memoize `running`/`retrying` arrays in `dashboard/root.tsx` via `useMemo` to fix exhaustive-deps warning

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`) — 0 warnings, 0 errors across all packages

## Issue

Resolves #47
