### PR TITLE
docs(sdk): add JSDoc to TrackerPluginHooks interface

### DIFF
--- a/packages/sdk/src/schemas/tracker.ts
+++ b/packages/sdk/src/schemas/tracker.ts
@@ -62,6 +62,66 @@ export interface TrackerPluginConfig {
 }
 
 /**
+ * Summary of an agent run returned after the agent process exits.
+ */
+export interface AgentResult {
+	readonly turnCount: number;
+	readonly inputTokens: number;
+	readonly outputTokens: number;
+	readonly lastMessage: string | null;
+}
+
+/**
+ * Optional lifecycle hooks a tracker plugin can provide.
+ *
+ * The orchestrator calls these hooks at key points during issue dispatch and
+ * agent execution. All hooks are **best-effort** — if a hook effect fails the
+ * error is logged and swallowed so it never interrupts the core dispatch loop.
+ *
+ * Plugins return a `TrackerPluginHooks` from their `hooks` factory function.
+ * When omitted, no hooks fire.
+ */
+export interface TrackerPluginHooks {
+	/**
+	 * Called immediately after an issue has been claimed and registered for
+	 * dispatch, before the agent process starts.
+	 *
+	 * Receives the {@link Issue} that was dispatched. Typically used for
+	 * tracker-side bookkeeping such as ensuring a workpad comment exists.
+	 *
+	 * Best-effort — failures are logged and swallowed.
+	 */
+	readonly onIssueDispatched: (
+		issue: Issue,
+	) => Effect.Effect<void, unknown>;
+
+	/**
+	 * Called after the agent process exits successfully for an issue.
+	 *
+	 * Receives the {@link Issue} and an {@link AgentResult} summarising the
+	 * run (turn count, token usage, last message).
+	 *
+	 * Best-effort — failures are logged and swallowed.
+	 */
+	readonly onAgentComplete: (
+		issue: Issue,
+		result: AgentResult,
+	) => Effect.Effect<void, unknown>;
+
+	/**
+	 * Called after the agent process exits with a failure for an issue.
+	 *
+	 * Receives the {@link Issue} and a stringified error describing the cause.
+	 *
+	 * Best-effort — failures are logged and swallowed.
+	 */
+	readonly onAgentFailed: (
+		issue: Issue,
+		error: string,
+	) => Effect.Effect<void, unknown>;
+}
+
+/**
  * Contract implemented by tracker plugins.
  *
  * A tracker plugin is an npm package or local module that exports a default


### PR DESCRIPTION
Add `TrackerPluginHooks` interface with JSDoc documenting the plugin lifecycle hooks (`onIssueDispatched`, `onAgentComplete`, `onAgentFailed`). Each hook documents when it is called, what it receives, and that failures are best-effort (logged and swallowed).

Also adds the `AgentResult` interface used by `onAgentComplete`.

## Changes
- `packages/sdk/src/schemas/tracker.ts`: Added `AgentResult` interface and `TrackerPluginHooks` interface with full JSDoc

## Validation
- SDK typecheck: pass
- Lint: pass (0 errors, pre-existing warnings only)
- Note: `@plot/plot` has pre-existing typecheck failures unrelated to this change (TrackerPlugin generic usage)

Resolves #53