### PR TITLE
#55: add build status and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/igorsheg/plot/actions"><img src="https://img.shields.io/github/actions/workflow/status/igorsheg/plot/ci.yml?branch=main&style=flat-square" alt="build status" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/igorsheg/plot?style=flat-square" alt="license" /></a>
+</p>
+
+<p align="center">
   orchestrate coding agents against an issue tracker.
 </p>
 


### PR DESCRIPTION
## Summary

Adds shields.io build status and license badges to the top of README.md.

## Changes

- Added GitHub Actions build status badge (shields.io)
- Added MIT license badge (shields.io)

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] Tests pass (`bun run test`)

## Issue

Resolves #55
