### PR TITLE
#62: add JSON export endpoint to observability API

### DIFF
--- a/packages/plot/src/observability-service.ts
+++ b/packages/plot/src/observability-service.ts
@@ -236,10 +236,77 @@ export const makeObservabilityApi = Effect.gen(function* () {
 		});
 	});
 
+	const getExportData = withOrchestratorAvailability(
+		orchestrator.getState.pipe(
+			Effect.map((state) => ({
+				timestamp: new Date().toISOString(),
+				running: Object.fromEntries(
+					[...state.running.entries()].map(([k, v]) => [
+						k,
+						{
+							issueId: v.issueId,
+							issueIdentifier: v.issueIdentifier,
+							state: v.state,
+							startedAt: v.startedAt,
+							workspacePath: v.workspacePath,
+							sessionId: v.sessionId,
+							lastEventAt: v.lastEventAt,
+							inputTokens: v.inputTokens,
+							outputTokens: v.outputTokens,
+							totalTokens: v.totalTokens,
+							turnCount: v.turnCount,
+							phase: v.phase,
+							lastMessage: v.lastMessage,
+						},
+					]),
+				),
+				claimed: [...state.claimed],
+				retryAttempts: Object.fromEntries(
+					[...state.retryAttempts.entries()].map(([k, v]) => [
+						k,
+						{
+							issueId: v.issueId,
+							identifier: v.identifier,
+							attempt: v.attempt,
+							dueAtMs: v.dueAtMs,
+							error: v.error,
+							reason: v.reason,
+						},
+					]),
+				),
+				issueArtifacts: Object.fromEntries(
+					[...state.issueArtifacts.entries()].map(([k, v]) => [
+						k,
+						{
+							issueId: v.issueId,
+							issueIdentifier: v.issueIdentifier,
+							workspacePath: v.workspacePath,
+							lastError: v.lastError,
+						},
+					]),
+				),
+				counters: {
+					totalInputTokens: state.totalInputTokens,
+					totalOutputTokens: state.totalOutputTokens,
+					totalTokens: state.totalTokens,
+					endedSessionSeconds: state.endedSessionSeconds,
+					commandQueueDepth: state.commandQueueDepth,
+					commandQueuePeak: state.commandQueuePeak,
+					commandQueuePressureCount: state.commandQueuePressureCount,
+					staleRetryDropCount: state.staleRetryDropCount,
+					retriesScheduledByReason: state.retriesScheduledByReason,
+					workerStopsByReason: state.workerStopsByReason,
+					workerExitsByReason: state.workerExitsByReason,
+				},
+			})),
+		),
+	);
+
 	return {
 		getState,
 		getIssue,
 		getEventLog,
+		getExportData,
 		triggerRefresh,
 		eventStream: orchestrator.eventStream,
 		stateStream,

--- a/packages/plot/src/server.ts
+++ b/packages/plot/src/server.ts
@@ -72,6 +72,24 @@ export function makeServer(
 		}),
 	).pipe(Layer.provide(ObservabilityLive));
 
+	const ExportRouteLive = HttpRouter.Default.use((router) =>
+		Effect.gen(function* () {
+			const api = yield* ObservabilityApi;
+			yield* router.get(
+				"/api/export",
+				Effect.gen(function* () {
+					const data = yield* api.getExportData;
+					return yield* HttpServerResponse.json(data, {
+						headers: {
+							"Content-Disposition":
+								'attachment; filename="plot-state.json"',
+						},
+					});
+				}),
+			);
+		}),
+	).pipe(Layer.provide(ObservabilityLive));
+
 	const startedAt = Date.now();
 
 	const HealthzLive = HttpRouter.Default.use((router) =>
@@ -149,6 +167,7 @@ export function makeServer(
 		Layer.provide(RpcLayer),
 		Layer.provide(HttpProtocol),
 		Layer.provide(SseRouteLive),
+		Layer.provide(ExportRouteLive),
 		Layer.provide(HealthzLive),
 		Layer.provide(BunHttpServer.layer({ port: config.port, idleTimeout: 120 })),
 		Layer.provide(StartupLive),


### PR DESCRIPTION
## Summary

Add a `GET /api/export` endpoint that returns the full orchestrator state as a downloadable JSON file.

## Changes

- Add `getExportData` method to `ObservabilityApi` in `observability-service.ts` — serializes running entries, claimed set, retry attempts, issue artifacts, and counters to plain JSON with an ISO timestamp
- Add `GET /api/export` route in `server.ts` with `Content-Disposition: attachment; filename="plot-state.json"` header
- Wire `ExportRouteLive` into the app layer

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

## Issue

Resolves #62
