### PR TITLE
#64: add PLOT_VERSION constant to sdk package

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,3 +10,4 @@ export * from "./schemas/workflow.js";
 export * from "./errors.js";
 export * from "./rpc.js";
 export * from "./plugin.js";
+export * from "./version.js";

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,0 +1,1 @@
+export const PLOT_VERSION: string = "0.0.1";


### PR DESCRIPTION
## Summary

Adds a `PLOT_VERSION` string constant to the sdk package, exported from the barrel.

## Changes

- Create `packages/sdk/src/version.ts` exporting `PLOT_VERSION` (`"0.0.1"`)
- Re-export from `packages/sdk/src/index.ts`

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

## Issue

Resolves #64
