### PR TITLE
add favicon to web dashboard

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>plot</title>
     <script>
       if (window.matchMedia("(prefers-color-scheme: dark)").matches) {

--- a/packages/web/public/favicon.svg
+++ b/packages/web/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#18181b"/>
+  <text x="16" y="23" font-family="system-ui,sans-serif" font-size="20" font-weight="700" fill="#fafafa" text-anchor="middle">P</text>
+</svg>


### PR DESCRIPTION
## Summary

Add a favicon to the plot web dashboard so the browser tab shows a "P" icon instead of the default blank icon.

## Changes

- Add `packages/web/public/favicon.svg` — dark rounded rect with white "P"
- Add `<link rel="icon">` to `packages/web/index.html`

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
