### PR TITLE
epic-tn7: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,15 @@
 root = true
 
 [*]
-indent_style = tab
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Summary

Updates .editorconfig file to use standard indentation settings with 2-space indents for TypeScript/JavaScript and 4-space indents for Markdown files.

## Changes

- Replaced general tab indentation with file-type specific spacing
- Added 2-space indentation for JavaScript/TypeScript files (.js, .jsx, .ts, .tsx)
- Added 4-space indentation for Markdown files (.md)
- Preserved existing utf-8, lf line endings, and whitespace trimming settings

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Tests pass (`bun run test`)  
- [x] Build passes (`bun run build`)
- [ ] Lint has pre-existing issues unrelated to this change

## Issue

Resolves epic-tn7