### PR TITLE
feat: update LICENSE copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Igor Sheg
+Copyright (c) 2026 Igor Sheg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the MIT license copyright year from 2025 to 2026 as requested.

## Changes
- Updated copyright year in LICENSE file from 2025 to 2026
- Maintained existing MIT license format and copyright holder 'Igor Sheg'

## Verification
- ✅ Typecheck passed
- ⚠️  Lint has pre-existing unrelated issues 
- ✅ Tests passed
- ✅ Build passed

Resolves #72