### PR TITLE
feat(scripts): add check:lockfile script to verify bun.lock sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fmt:check": "oxfmt --check",
     "typecheck": "turbo run typecheck",
     "check": "bun run typecheck && bun run lint && bun run fmt:check",
+    "check:lockfile": "bun install --frozen-lockfile --dry-run",
     "test": "turbo run test",
     "dev": "turbo run dev --filter=@plot/plot --filter=@plot/web --parallel",
     "dev:server": "turbo run dev --filter=@plot/plot",


### PR DESCRIPTION
## Summary

Adds a `check:lockfile` script to the root package.json that developers can use to verify the lockfile is in sync with package.json dependencies.

## Changes

- Added `check:lockfile` script that runs `bun install --frozen-lockfile --dry-run`
- Script catches lockfile drift by failing when dependencies in package.json aren't reflected in bun.lock

## Testing

✅ Script passes when lockfile is in sync  
✅ Script fails when lockfile drift is detected (tested with fake dependency)  
✅ Existing scripts continue to work  

## Usage

```bash
bun run check:lockfile
```

Resolves #80