### PR TITLE
feat: deterministic plugin kind classification with protocol prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ shared flags for `plot-ai`, `serve`, and `web`:
 | `--log-format`  | `pretty`        | server log format: `pretty` or `json`                            |
 | `--verbose`     | `false`         | enable non-error human output (quiet by default)                 |
 | `--json`        | `false`         | machine-readable ndjson output on stdout. practical with `serve` |
+| `--refresh-plugins` | `false`    | re-fetch npm tracker plugins, ignoring cached installations      |
 
 ## tracker plugins
 
-plot ships with one built-in tracker: `github`. custom trackers implement `TrackerPluginDefinition` from `@plot/sdk` and are referenced in `WORKFLOW.md` as a package specifier (`@acme/plot-tracker-jira`) or local path (`./trackers/jira.ts`).
+plot ships with built-in trackers (`github`, `beads`). custom trackers implement `TrackerPluginDefinition` from `@plot/sdk`:
 
 ```ts
 import type { TrackerPluginDefinition } from "@plot/sdk";
@@ -92,6 +93,27 @@ const plugin: TrackerPluginDefinition = {
 
 export default plugin;
 ```
+
+### plugin resolution
+
+the `tracker.kind` field in `WORKFLOW.md` determines how the plugin is loaded:
+
+| kind value | resolution |
+|---|---|
+| `github` | built-in tracker |
+| `./trackers/jira.ts` | local file (relative to cwd) |
+| `/abs/path/tracker.ts` | local file (absolute) |
+| `~/my-tracker/index.ts` | local file (tilde expands to home) |
+| `@acme/plot-tracker-jira` | npm package (installed to `~/.plot/plugins/`) |
+
+explicit prefixes are supported for clarity:
+
+| kind value | resolution |
+|---|---|
+| `file:./trackers/jira.ts` | local file |
+| `npm:@acme/plot-tracker-jira` | npm package |
+
+npm plugins are installed on first use via `bun add` and cached by package name. the registry is auto-detected from the consumer repo's `.npmrc` or `.yarnrc.yml`. use `--refresh-plugins` to re-fetch the latest version.
 
 tracker plugins are read-only clients — the coding agent handles all writes (state transitions, comments, pr links) using cli tools in the runtime environment.
 

--- a/packages/plot/src/core/plugin-kind.test.ts
+++ b/packages/plot/src/core/plugin-kind.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { classifyPluginKind } from "./plugin-kind.js";
+
+const CWD = "/workspace/my-repo";
+
+describe("classifyPluginKind", () => {
+	describe("explicit npm: prefix", () => {
+		test("scoped package", () => {
+			const result = classifyPluginKind("npm:@wix/plot-jira-tracker", CWD);
+			expect(result).toEqual({ type: "npm", specifier: "@wix/plot-jira-tracker" });
+		});
+
+		test("unscoped package", () => {
+			const result = classifyPluginKind("npm:my-tracker", CWD);
+			expect(result).toEqual({ type: "npm", specifier: "my-tracker" });
+		});
+	});
+
+	describe("explicit file: prefix", () => {
+		test("relative path", () => {
+			const result = classifyPluginKind("file:./trackers/custom.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: resolve(CWD, "./trackers/custom.ts") });
+		});
+
+		test("absolute path", () => {
+			const result = classifyPluginKind("file:/abs/path/tracker.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: "/abs/path/tracker.ts" });
+		});
+
+		test("tilde path", () => {
+			const result = classifyPluginKind("file:~/my-trackers/custom.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: resolve(homedir(), "my-trackers/custom.ts") });
+		});
+	});
+
+	describe("implicit local paths (no prefix)", () => {
+		test("relative with dot-slash", () => {
+			const result = classifyPluginKind("./trackers/custom.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: resolve(CWD, "./trackers/custom.ts") });
+		});
+
+		test("relative with dot-dot", () => {
+			const result = classifyPluginKind("../shared/tracker.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: resolve(CWD, "../shared/tracker.ts") });
+		});
+
+		test("absolute path", () => {
+			const result = classifyPluginKind("/home/user/trackers/custom.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: "/home/user/trackers/custom.ts" });
+		});
+
+		test("tilde path", () => {
+			const result = classifyPluginKind("~/my-tracker/index.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: resolve(homedir(), "my-tracker/index.ts") });
+		});
+
+		test("bare tilde", () => {
+			const result = classifyPluginKind("~tracker/index.ts", CWD);
+			expect(result).toEqual({ type: "local", specifier: resolve(homedir(), "tracker/index.ts") });
+		});
+	});
+
+	describe("implicit npm (no prefix, no path indicators)", () => {
+		test("scoped package", () => {
+			const result = classifyPluginKind("@wix/plot-jira-tracker", CWD);
+			expect(result).toEqual({ type: "npm", specifier: "@wix/plot-jira-tracker" });
+		});
+
+		test("unscoped package", () => {
+			const result = classifyPluginKind("my-tracker-plugin", CWD);
+			expect(result).toEqual({ type: "npm", specifier: "my-tracker-plugin" });
+		});
+	});
+});

--- a/packages/plot/src/core/plugin-kind.ts
+++ b/packages/plot/src/core/plugin-kind.ts
@@ -1,0 +1,67 @@
+/**
+ * Plugin kind classification.
+ *
+ * Determines how a tracker plugin `kind` string from WORKFLOW.md should be resolved:
+ *
+ * - **builtin**: a well-known name like "github" or "beads", resolved from the built-in registry.
+ * - **local**: a filesystem path (relative, absolute, or tilde-prefixed), loaded via import().
+ * - **npm**: an npm package specifier, installed to ~/.plot/plugins/ and imported from there.
+ *
+ * Explicit prefixes are supported for clarity:
+ *   kind: 'npm:@wix/plot-jira-tracker'
+ *   kind: 'file:./trackers/custom.ts'
+ *
+ * Without a prefix, classification uses path heuristics:
+ *   starts with '.', '/', '~'  →  local
+ *   otherwise                   →  npm
+ *
+ * Builtins are resolved before this classifier runs (checked separately).
+ */
+
+import { resolve as resolvePath } from "node:path";
+import { homedir } from "node:os";
+
+const NPM_PREFIX = "npm:";
+const FILE_PREFIX = "file:";
+
+export type PluginKindType = "local" | "npm";
+
+export interface PluginKind {
+	readonly type: PluginKindType;
+	readonly specifier: string;
+}
+
+/**
+ * Classify a non-builtin plugin kind string into a resolved PluginKind.
+ *
+ * @param kind - raw kind string from WORKFLOW.md (after builtin check)
+ * @param cwd - working directory for resolving relative paths
+ */
+export function classifyPluginKind(kind: string, cwd: string): PluginKind {
+	if (kind.startsWith(NPM_PREFIX)) {
+		return { type: "npm", specifier: kind.slice(NPM_PREFIX.length) };
+	}
+
+	if (kind.startsWith(FILE_PREFIX)) {
+		return { type: "local", specifier: expandPath(kind.slice(FILE_PREFIX.length), cwd) };
+	}
+
+	if (isLocalPath(kind)) {
+		return { type: "local", specifier: expandPath(kind, cwd) };
+	}
+
+	return { type: "npm", specifier: kind };
+}
+
+function isLocalPath(kind: string): boolean {
+	return kind.startsWith(".")
+		|| kind.startsWith("/")
+		|| kind.startsWith("~");
+}
+
+function expandPath(path: string, cwd: string): string {
+	if (path.startsWith("~")) {
+		return resolvePath(homedir(), path.slice(path.startsWith("~/") ? 2 : 1));
+	}
+	return resolvePath(cwd, path);
+}

--- a/packages/plot/src/runtime-builder.ts
+++ b/packages/plot/src/runtime-builder.ts
@@ -3,6 +3,7 @@ import { mkdirSync, existsSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
+import { classifyPluginKind } from "./core/plugin-kind.js";
 import { BunServices } from "@effect/platform-bun";
 import { Effect, Layer, Logger, LogLevel, ManagedRuntime, References } from "effect";
 import { AtomRegistry } from "effect/unstable/reactivity";
@@ -308,14 +309,15 @@ export function resolvePlugin(resolved: ResolvedConfig, options?: ResolvePluginO
 
 	return Effect.gen(function* () {
 		const kind = resolved.trackerKind;
-		const resolvedPath = kind.startsWith(".")
-			? resolvePath(process.cwd(), kind)
-			: yield* resolveNpmPlugin(kind, { refresh: options?.refreshPlugins });
+		const pluginKind = classifyPluginKind(kind, process.cwd());
+		const resolvedPath = pluginKind.type === "local"
+			? pluginKind.specifier
+			: yield* resolveNpmPlugin(pluginKind.specifier, { refresh: options?.refreshPlugins });
 		const mod = yield* Effect.tryPromise({
 			try: () => import(resolvedPath) as Promise<{ default?: AnyPluginDefinition }>,
 			catch: (cause) =>
 				new Error(
-					`Failed to load tracker plugin "${kind}": ${cause instanceof Error ? cause.message : String(cause)}`,
+					`Failed to load tracker plugin "${kind}" (${pluginKind.type}:${pluginKind.specifier}): ${cause instanceof Error ? cause.message : String(cause)}`,
 				),
 		}).pipe(Effect.orDie);
 		const definition = mod.default;


### PR DESCRIPTION
## what

Replace fragile `startsWith('.')` heuristics for plugin resolution with a typed classifier that's deterministic and supports explicit protocol prefixes.

### plugin kind resolution

| input | type | specifier |
|-------|------|-----------|
| `github` | builtin | (resolved from registry) |
| `@wix/plot-jira-tracker` | npm | `@wix/plot-jira-tracker` |
| `npm:@wix/plot-jira-tracker` | npm | `@wix/plot-jira-tracker` |
| `./trackers/custom.ts` | local | `/abs/resolved/path` |
| `/abs/path/tracker.ts` | local | `/abs/path/tracker.ts` |
| `~/my-tracker/index.ts` | local | `/home/user/my-tracker/index.ts` |
| `file:./trackers/custom.ts` | local | `/abs/resolved/path` |

### why

The previous code used `kind.startsWith('.')` to distinguish local from npm. This broke absolute paths (`/home/...`), tilde paths (`~/...`), and was ambiguous for bare names. The fix-on-fix approach (`startsWith('.') || startsWith('/')`) was heading toward an ever-growing list of heuristics.

### implementation

- `core/plugin-kind.ts` — pure classifier function, no side effects
- `PluginKind` type: `{ type: 'local' | 'npm'; specifier: string }`
- explicit prefixes (`npm:`, `file:`) always win
- implicit classification: `.`, `/`, `~` → local; everything else → npm
- tilde expansion via `os.homedir()`
- 12 test cases covering all combinations

### files
- `core/plugin-kind.ts` — new module
- `core/plugin-kind.test.ts` — 12 tests
- `runtime-builder.ts` — uses classifier instead of inline heuristics