### PR TITLE
feat: plugin API v2 — defineTracker, renamed types, simplified fetchRunContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,24 +75,27 @@ shared flags for `plot-ai`, `serve`, and `web`:
 
 ## tracker plugins
 
-plot ships with built-in trackers (`github`, `beads`). custom trackers implement `TrackerPluginDefinition` from `@plot/sdk`:
+plot ships with built-in trackers (`github`, `beads`). custom trackers use `defineTracker` from `@plot/sdk`:
 
 ```ts
-import type { TrackerPluginDefinition } from "@plot/sdk";
+import { defineTracker } from "@plot/sdk";
 
-const plugin: TrackerPluginDefinition = {
+export default defineTracker({
   name: "acme",
-  async factory() {
-    return {
-      async fetchCandidateIssues() {
-        return [];
-      },
-    };
+  config(raw) {
+    return { projectKey: raw.project_key as string };
   },
-};
-
-export default plugin;
+  async setup(ctx) {
+    const client = await connect(ctx.config.projectKey);
+    return { client };
+  },
+  async fetchCandidateIssues(ctx, dispatchStates) {
+    return ctx.client.listIssues(dispatchStates);
+  },
+});
 ```
+
+`defineTracker` provides a typed `ctx` to every method with your validated config and workflow states. the optional `setup()` hook runs once and returns shared resources (API clients, auth tokens) that are merged into `ctx` — no re-initialization per method call.
 
 ### plugin resolution
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ shared flags for `plot-ai`, `serve`, and `web`:
 plot ships with built-in trackers (`github`, `beads`). custom trackers use `defineTracker` from `@plot/sdk`:
 
 ```ts
-import { defineTracker } from "@plot/sdk";
+import { defineTracker } from "@plot/sdk/plugin";
 
 export default defineTracker({
   name: "acme",

--- a/packages/plot/src/runtime-builder.ts
+++ b/packages/plot/src/runtime-builder.ts
@@ -8,13 +8,14 @@ import { BunServices } from "@effect/platform-bun";
 import { Effect, Layer, Logger, LogLevel, ManagedRuntime, References } from "effect";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import {
-	type PlainTrackerClient,
+	type PluginTrackerClient,
 	type TrackerPluginDefinition,
-	type IssueLike,
-	type IssueStateEntryLike,
-	type TrackerRunContextLike,
+	type PluginIssue,
+	type PluginIssueState,
+	type PluginRunContextRaw,
 	type TrackerPluginConfig,
 	type TrackerError,
+	buildRunContext,
 	PluginAuthError,
 	PluginRateLimitError,
 	PluginNotFoundError,
@@ -92,7 +93,7 @@ function mapPluginError(error: unknown, operation: string): TrackerError {
 }
 
 
-function normalizeIssue(plain: IssueLike): Issue {
+function normalizeIssue(plain: PluginIssue): Issue {
 	return new Issue({
 		id: plain.id,
 		identifier: plain.identifier,
@@ -118,22 +119,24 @@ function normalizeIssue(plain: IssueLike): Issue {
 	});
 }
 
-function normalizeIssueStateEntry(plain: IssueStateEntryLike): IssueStateEntry {
+function normalizeIssueStateEntry(plain: PluginIssueState): IssueStateEntry {
 	return new IssueStateEntry({ id: plain.id, state: plain.state });
 }
 
-function normalizeRunContext(plain: TrackerRunContextLike | null): TrackerRunContext | null {
-	if (plain == null) return null;
+function normalizeRunContext(raw: PluginRunContextRaw | null): TrackerRunContext | null {
+	if (raw == null) return null;
+	const built = buildRunContext(raw);
+	if (built == null) return null;
 	return new TrackerRunContext({
-		raw: plain.raw ?? null,
-		promptContext: plain.promptContext ?? null,
-		workpad: plain.workpad ?? null,
-		reviewFeedback: plain.reviewFeedback ?? null,
-		workpadSections: (plain.workpadSections ?? []).map((s) => new WorkpadSection(s)),
+		raw: built.raw ?? null,
+		promptContext: built.promptContext ?? null,
+		workpad: built.workpad ?? null,
+		reviewFeedback: built.reviewFeedback ?? null,
+		workpadSections: (built.workpadSections ?? []).map((s) => new WorkpadSection(s)),
 	});
 }
 
-function adaptTrackerClient(plain: PlainTrackerClient): Layer.Layer<TrackerClient> {
+function adaptTrackerClient(plain: PluginTrackerClient): Layer.Layer<TrackerClient> {
 	return Layer.succeed(
 		TrackerClient,
 		TrackerClient.of({

--- a/packages/plot/src/runtime-builder.ts
+++ b/packages/plot/src/runtime-builder.ts
@@ -8,11 +8,11 @@ import { BunServices } from "@effect/platform-bun";
 import { Effect, Layer, Logger, LogLevel, ManagedRuntime, References } from "effect";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import {
-	type PluginTrackerClient,
+	type TrackerPluginClient,
 	type TrackerPluginDefinition,
-	type PluginIssue,
-	type PluginIssueState,
-	type PluginRunContextRaw,
+	type TrackerIssue,
+	type TrackerIssueState,
+	type TrackerRunContextRaw,
 	type TrackerPluginConfig,
 	type TrackerError,
 	buildRunContext,
@@ -93,7 +93,7 @@ function mapPluginError(error: unknown, operation: string): TrackerError {
 }
 
 
-function normalizeIssue(plain: PluginIssue): Issue {
+function normalizeIssue(plain: TrackerIssue): Issue {
 	return new Issue({
 		id: plain.id,
 		identifier: plain.identifier,
@@ -119,11 +119,11 @@ function normalizeIssue(plain: PluginIssue): Issue {
 	});
 }
 
-function normalizeIssueStateEntry(plain: PluginIssueState): IssueStateEntry {
+function normalizeIssueStateEntry(plain: TrackerIssueState): IssueStateEntry {
 	return new IssueStateEntry({ id: plain.id, state: plain.state });
 }
 
-function normalizeRunContext(raw: PluginRunContextRaw | null): TrackerRunContext | null {
+function normalizeRunContext(raw: TrackerRunContextRaw | null): TrackerRunContext | null {
 	if (raw == null) return null;
 	const built = buildRunContext(raw);
 	if (built == null) return null;
@@ -136,7 +136,7 @@ function normalizeRunContext(raw: PluginRunContextRaw | null): TrackerRunContext
 	});
 }
 
-function adaptTrackerClient(plain: PluginTrackerClient): Layer.Layer<TrackerClient> {
+function adaptTrackerClient(plain: TrackerPluginClient): Layer.Layer<TrackerClient> {
 	return Layer.succeed(
 		TrackerClient,
 		TrackerClient.of({

--- a/packages/plot/src/tracker/__fixtures__/fake-jira-tracker/index.ts
+++ b/packages/plot/src/tracker/__fixtures__/fake-jira-tracker/index.ts
@@ -1,13 +1,8 @@
-import type { TrackerPluginDefinition } from "@plot/sdk";
-const plugin: TrackerPluginDefinition = {
-	name: "fake-jira",
-	async factory() {
-		return {
-			async fetchCandidateIssues() {
-				return [];
-			},
-		};
-	},
-};
+import { defineTracker } from "@plot/sdk";
 
-export default plugin;
+export default defineTracker({
+	name: "fake-jira",
+	async fetchCandidateIssues() {
+		return [];
+	},
+});

--- a/packages/plot/src/tracker/__fixtures__/fake-minimal-tracker/index.ts
+++ b/packages/plot/src/tracker/__fixtures__/fake-minimal-tracker/index.ts
@@ -1,14 +1,8 @@
-import type { TrackerPluginDefinition } from "@plot/sdk";
+import { defineTracker } from "@plot/sdk";
 
-const plugin: TrackerPluginDefinition = {
+export default defineTracker({
 	name: "fake-minimal",
-	async factory() {
-		return {
-			async fetchCandidateIssues() {
-				return [];
-			},
-		};
+	async fetchCandidateIssues() {
+		return [];
 	},
-};
-
-export default plugin;
+});

--- a/packages/plot/src/tracker/beads/beads.test.ts
+++ b/packages/plot/src/tracker/beads/beads.test.ts
@@ -218,7 +218,7 @@ describe("beads tracker", () => {
 		expect(issues[2]?.state).toBe("plot:rework");
 	});
 
-	test("maps beads issue fields to IssueLike", async () => {
+	test("maps beads issue fields to TrackerIssue", async () => {
 		await setupFakeBd({
 			issuesFixture: [
 				{

--- a/packages/plot/src/tracker/beads/index.ts
+++ b/packages/plot/src/tracker/beads/index.ts
@@ -2,9 +2,9 @@ import { execFileAsync } from "../../lib/exec.js";
 import {
 	defineTracker,
 	normalizeState,
-	type PluginIssue,
-	type PluginIssueState,
-	type PluginRunContextRaw,
+	type TrackerIssue,
+	type TrackerIssueState,
+	type TrackerRunContextRaw,
 	type TrackerPluginConfig,
 } from "@plot/sdk";
 import { BeadsDaemonTransport, tryCreateBeadsDaemonTransport } from "./daemon-transport.js";
@@ -104,7 +104,7 @@ async function createBeadsOps(config: {
 		return bd.status;
 	};
 
-	const mapIssue = (bd: BdIssue): PluginIssue => ({
+	const mapIssue = (bd: BdIssue): TrackerIssue => ({
 		id: bd.id,
 		identifier: bd.id,
 		title: bd.title,
@@ -119,7 +119,7 @@ async function createBeadsOps(config: {
 	const fetchRunContext = async (
 		issueId: string,
 		state: string,
-	): Promise<PluginRunContextRaw | null> => {
+	): Promise<TrackerRunContextRaw | null> => {
 		let comments: ReadonlyArray<{ text: string }> = [];
 		try {
 			const issue = await viewIssue(issueId);
@@ -195,7 +195,7 @@ export default defineTracker<BeadsTrackerConfig, BeadsSetup>({
 		return allIssues
 			.filter((issue) => wantedIds.has(issue.id))
 			.map(
-				(issue): PluginIssueState => ({
+				(issue): TrackerIssueState => ({
 					id: issue.id,
 					state: ctx.ops.mapState(issue),
 				}),

--- a/packages/plot/src/tracker/beads/index.ts
+++ b/packages/plot/src/tracker/beads/index.ts
@@ -1,13 +1,11 @@
 import { execFileAsync } from "../../lib/exec.js";
 import {
-	buildRunContext,
+	defineTracker,
 	normalizeState,
-	type IssueLike,
-	type IssueStateEntryLike,
-	type PlainTrackerClient,
+	type PluginIssue,
+	type PluginIssueState,
+	type PluginRunContextRaw,
 	type TrackerPluginConfig,
-	type TrackerPluginDefinition,
-	type TrackerRunContextLike,
 } from "@plot/sdk";
 import { BeadsDaemonTransport, tryCreateBeadsDaemonTransport } from "./daemon-transport.js";
 import {
@@ -106,7 +104,7 @@ async function createBeadsOps(config: {
 		return bd.status;
 	};
 
-	const mapIssue = (bd: BdIssue): IssueLike => ({
+	const mapIssue = (bd: BdIssue): PluginIssue => ({
 		id: bd.id,
 		identifier: bd.id,
 		title: bd.title,
@@ -121,7 +119,7 @@ async function createBeadsOps(config: {
 	const fetchRunContext = async (
 		issueId: string,
 		state: string,
-	): Promise<TrackerRunContextLike | null> => {
+	): Promise<PluginRunContextRaw | null> => {
 		let comments: ReadonlyArray<{ text: string }> = [];
 		try {
 			const issue = await viewIssue(issueId);
@@ -141,7 +139,7 @@ async function createBeadsOps(config: {
 			reviews = await fetchPrReviewFeedback(issueId, repoArgs, workspaceRoot);
 		}
 
-		return buildRunContext({ workpad, reviewFeedback: reviews });
+		return { workpad, reviewFeedback: reviews };
 	};
 
 	return {
@@ -153,56 +151,57 @@ async function createBeadsOps(config: {
 	};
 }
 
-const plugin: TrackerPluginDefinition<BeadsTrackerConfig> = {
+type BeadsSetup = {
+	ops: Awaited<ReturnType<typeof createBeadsOps>>;
+};
+
+export default defineTracker<BeadsTrackerConfig, BeadsSetup>({
 	name: "beads",
-	validateConfig(raw: TrackerPluginConfig): BeadsTrackerConfig {
+	config(raw: TrackerPluginConfig): BeadsTrackerConfig {
 		return {
 			...validateCommonTrackerFields(raw),
 			beadsDir: typeof raw["beadsDir"] === "string" ? raw["beadsDir"] : undefined,
 		};
 	},
-	async factory(config): Promise<PlainTrackerClient> {
+	async setup(ctx) {
 		const allStates = deriveAllStates(
-			config.dispatchStates,
-			config.parkedStates,
-			config.terminalStates,
+			ctx.config.dispatchStates,
+			ctx.config.parkedStates,
+			ctx.config.terminalStates,
 		);
-
 		const ops = await createBeadsOps({
-			beadsDir: config.beadsDir,
-			githubRepo: config.githubRepo,
-			dispatchStates: config.dispatchStates ?? [],
+			beadsDir: ctx.config.beadsDir,
+			githubRepo: ctx.config.githubRepo,
+			dispatchStates: ctx.config.dispatchStates ?? [],
 			allStates,
 		});
-
-		return {
-			async fetchCandidateIssues(dispatchStates) {
-				const bdIssues = await ops.listAllIssues();
-				const issues = bdIssues.map(ops.mapIssue);
-				const normalized = new Set(dispatchStates.map(normalizeState));
-				return issues.filter((i) => normalized.has(normalizeState(i.state)));
-			},
-			async fetchIssuesByStates(states) {
-				const bdIssues = await ops.listAllIssues();
-				const issues = bdIssues.map(ops.mapIssue);
-				const normalized = new Set(states.map(normalizeState));
-				return issues.filter((i) => normalized.has(normalizeState(i.state)));
-			},
-			async fetchIssueStatesByIds(ids) {
-				const wantedIds = new Set(ids);
-				const allIssues = await ops.listAllIssues();
-				return allIssues
-					.filter((issue) => wantedIds.has(issue.id))
-					.map(
-						(issue): IssueStateEntryLike => ({
-							id: issue.id,
-							state: ops.mapState(issue),
-						}),
-					);
-			},
-			fetchRunContext: (issueId, state) => ops.fetchRunContext(issueId, state),
-		};
+		return { ops };
 	},
-};
-
-export default plugin;
+	async fetchCandidateIssues(ctx, dispatchStates) {
+		const bdIssues = await ctx.ops.listAllIssues();
+		const issues = bdIssues.map(ctx.ops.mapIssue);
+		const normalized = new Set(dispatchStates.map(normalizeState));
+		return issues.filter((i) => normalized.has(normalizeState(i.state)));
+	},
+	async fetchIssuesByStates(ctx, states) {
+		const bdIssues = await ctx.ops.listAllIssues();
+		const issues = bdIssues.map(ctx.ops.mapIssue);
+		const normalized = new Set(states.map(normalizeState));
+		return issues.filter((i) => normalized.has(normalizeState(i.state)));
+	},
+	async fetchIssueStatesByIds(ctx, ids) {
+		const wantedIds = new Set(ids);
+		const allIssues = await ctx.ops.listAllIssues();
+		return allIssues
+			.filter((issue) => wantedIds.has(issue.id))
+			.map(
+				(issue): PluginIssueState => ({
+					id: issue.id,
+					state: ctx.ops.mapState(issue),
+				}),
+			);
+	},
+	async fetchRunContext(ctx, issueId, state) {
+		return ctx.ops.fetchRunContext(issueId, state);
+	},
+});

--- a/packages/plot/src/tracker/github/index.ts
+++ b/packages/plot/src/tracker/github/index.ts
@@ -1,13 +1,11 @@
 import {
-	buildRunContext,
+	defineTracker,
 	normalizeState,
 	PluginNotFoundError,
-	type IssueLike,
-	type IssueStateEntryLike,
-	type PlainTrackerClient,
+	type PluginIssue,
+	type PluginIssueState,
+	type PluginRunContextRaw,
 	type TrackerPluginConfig,
-	type TrackerPluginDefinition,
-	type TrackerRunContextLike,
 } from "@plot/sdk";
 import {
 	type CommonTrackerConfig,
@@ -179,7 +177,7 @@ function createGithubOps(config: GithubOpsConfig) {
 		url: string;
 		createdAt: string;
 		updatedAt: string;
-	}): IssueLike => ({
+	}): PluginIssue => ({
 		id: String(gh.number),
 		identifier: `#${gh.number}`,
 		title: gh.title,
@@ -194,7 +192,7 @@ function createGithubOps(config: GithubOpsConfig) {
 	const fetchRunContext = async (
 		issueId: string,
 		state: string,
-	): Promise<TrackerRunContextLike | null> => {
+	): Promise<PluginRunContextRaw | null> => {
 		let commentsRaw: ReadonlyArray<{ body: string }> = [];
 		try {
 			const data = await ghApiJson<{ comments: GhComment[] }>([
@@ -230,7 +228,7 @@ function createGithubOps(config: GithubOpsConfig) {
 			]);
 		}
 
-		return buildRunContext({ workpad, reviewFeedback: reviews });
+		return { workpad, reviewFeedback: reviews };
 	};
 
 	return {
@@ -244,57 +242,62 @@ function createGithubOps(config: GithubOpsConfig) {
 
 type GithubTrackerConfig = CommonTrackerConfig;
 
-const plugin: TrackerPluginDefinition<GithubTrackerConfig> = {
+type GithubSetup = {
+	owner: string;
+	repo: string;
+	repoArgs: string[];
+	ops: ReturnType<typeof createGithubOps>;
+};
+
+export default defineTracker<GithubTrackerConfig, GithubSetup>({
 	name: "github",
-	validateConfig(raw: TrackerPluginConfig): GithubTrackerConfig {
+	config(raw: TrackerPluginConfig): GithubTrackerConfig {
 		return validateCommonTrackerFields(raw);
 	},
-	async factory(config): Promise<PlainTrackerClient> {
+	async setup(ctx) {
 		await getAuthToken();
-		const { owner, repo } = config.githubRepo
-			? parseRepoSlug(config.githubRepo)
+		const { owner, repo } = ctx.config.githubRepo
+			? parseRepoSlug(ctx.config.githubRepo)
 			: await detectRepo();
-
+		const repoArgs = ["--repo", `${owner}/${repo}`];
 		const ops = createGithubOps({
 			owner,
 			repo,
-			dispatchStates: config.dispatchStates,
-			parkedStates: config.parkedStates,
-			terminalStates: config.terminalStates,
+			dispatchStates: ctx.config.dispatchStates,
+			parkedStates: ctx.config.parkedStates,
+			terminalStates: ctx.config.terminalStates,
 		});
-
-		return {
-			async fetchCandidateIssues(dispatchStates) {
-				const ghIssues = await ops.listIssues("open");
-				const issues = ghIssues.map(ops.mapIssue);
-				const normalized = new Set(dispatchStates.map(normalizeState));
-				return issues.filter((i) => normalized.has(normalizeState(i.state)));
-			},
-			async fetchIssuesByStates(states) {
-				const ghIssues = await ops.listIssues("all");
-				const issues = ghIssues.map(ops.mapIssue);
-				const normalized = new Set(states.map(normalizeState));
-				return issues.filter((i) => normalized.has(normalizeState(i.state)));
-			},
-			async fetchIssueStatesByIds(ids) {
-				const results = await Promise.all(
-					ids.map(async (id) => {
-						try {
-							const gh = await ops.viewIssue(id);
-							return [
-								{ id: String(gh.number), state: ops.mapState(gh) },
-							] as IssueStateEntryLike[];
-						} catch (e) {
-							if (e instanceof PluginNotFoundError) return [];
-							throw e;
-						}
-					}),
-				);
-				return results.flat();
-			},
-			fetchRunContext: (issueId, state) => ops.fetchRunContext(issueId, state),
-		};
+		return { owner, repo, repoArgs, ops };
 	},
-};
-
-export default plugin;
+	async fetchCandidateIssues(ctx, dispatchStates) {
+		const ghIssues = await ctx.ops.listIssues("open");
+		const issues = ghIssues.map(ctx.ops.mapIssue);
+		const normalized = new Set(dispatchStates.map(normalizeState));
+		return issues.filter((i) => normalized.has(normalizeState(i.state)));
+	},
+	async fetchIssuesByStates(ctx, states) {
+		const ghIssues = await ctx.ops.listIssues("all");
+		const issues = ghIssues.map(ctx.ops.mapIssue);
+		const normalized = new Set(states.map(normalizeState));
+		return issues.filter((i) => normalized.has(normalizeState(i.state)));
+	},
+	async fetchIssueStatesByIds(ctx, ids) {
+		const results = await Promise.all(
+			ids.map(async (id) => {
+				try {
+					const gh = await ctx.ops.viewIssue(id);
+					return [
+						{ id: String(gh.number), state: ctx.ops.mapState(gh) },
+					] as PluginIssueState[];
+				} catch (e) {
+					if (e instanceof PluginNotFoundError) return [];
+					throw e;
+				}
+			}),
+		);
+		return results.flat();
+	},
+	async fetchRunContext(ctx, issueId, state) {
+		return ctx.ops.fetchRunContext(issueId, state);
+	},
+});

--- a/packages/plot/src/tracker/github/index.ts
+++ b/packages/plot/src/tracker/github/index.ts
@@ -2,9 +2,9 @@ import {
 	defineTracker,
 	normalizeState,
 	PluginNotFoundError,
-	type PluginIssue,
-	type PluginIssueState,
-	type PluginRunContextRaw,
+	type TrackerIssue,
+	type TrackerIssueState,
+	type TrackerRunContextRaw,
 	type TrackerPluginConfig,
 } from "@plot/sdk";
 import {
@@ -177,7 +177,7 @@ function createGithubOps(config: GithubOpsConfig) {
 		url: string;
 		createdAt: string;
 		updatedAt: string;
-	}): PluginIssue => ({
+	}): TrackerIssue => ({
 		id: String(gh.number),
 		identifier: `#${gh.number}`,
 		title: gh.title,
@@ -192,7 +192,7 @@ function createGithubOps(config: GithubOpsConfig) {
 	const fetchRunContext = async (
 		issueId: string,
 		state: string,
-	): Promise<PluginRunContextRaw | null> => {
+	): Promise<TrackerRunContextRaw | null> => {
 		let commentsRaw: ReadonlyArray<{ body: string }> = [];
 		try {
 			const data = await ghApiJson<{ comments: GhComment[] }>([
@@ -288,7 +288,7 @@ export default defineTracker<GithubTrackerConfig, GithubSetup>({
 					const gh = await ctx.ops.viewIssue(id);
 					return [
 						{ id: String(gh.number), state: ctx.ops.mapState(gh) },
-					] as PluginIssueState[];
+					] as TrackerIssueState[];
 				} catch (e) {
 					if (e instanceof PluginNotFoundError) return [];
 					throw e;

--- a/packages/sdk/src/plugin/helpers.ts
+++ b/packages/sdk/src/plugin/helpers.ts
@@ -1,5 +1,3 @@
-import type { TrackerRunContextLike } from "./types.js";
-
 function normalizeBlock(value: string | null | undefined): string {
 	return (value ?? "").replace(/\r\n/g, "\n").trim();
 }
@@ -51,7 +49,13 @@ export const normalizeState = (s: string): string => s.trim().toLowerCase();
 export function buildRunContext(input: {
 	workpad: string | null;
 	reviewFeedback?: string | null;
-}): TrackerRunContextLike | null {
+}): {
+	raw: string | null;
+	promptContext: string | null;
+	workpad: string | null;
+	reviewFeedback: string | null;
+	workpadSections: ReadonlyArray<{ title: string; body: string; itemCount: number }>;
+} | null {
 	const workpad = normalizeBlock(input.workpad);
 	const reviewFeedback = normalizeBlock(input.reviewFeedback);
 	const sections = parseWorkpadSectionsPlain(workpad || null);

--- a/packages/sdk/src/plugin/types.ts
+++ b/packages/sdk/src/plugin/types.ts
@@ -1,5 +1,5 @@
 /** Issue shape returned by tracker plugin methods. */
-export interface PluginIssue {
+export interface TrackerIssue {
 	readonly id: string;
 	readonly identifier: string;
 	readonly title: string;
@@ -23,13 +23,13 @@ export interface PluginIssue {
 }
 
 /** Minimal issue state entry returned by fetchIssueStatesByIds. */
-export interface PluginIssueState {
+export interface TrackerIssueState {
 	readonly id: string;
 	readonly state: string;
 }
 
 /** Raw run context returned by plugin fetchRunContext — the orchestrator parses sections. */
-export interface PluginRunContextRaw {
+export interface TrackerRunContextRaw {
 	readonly workpad: string | null;
 	readonly reviewFeedback?: string | null;
 }
@@ -47,20 +47,20 @@ export interface TrackerPluginConfig {
 }
 
 /** Client interface a tracker plugin must implement. */
-export interface PluginTrackerClient {
+export interface TrackerPluginClient {
 	readonly fetchCandidateIssues: (
 		dispatchStates: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<PluginIssue>>;
+	) => Promise<ReadonlyArray<TrackerIssue>>;
 	readonly fetchIssuesByStates?: (
 		states: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<PluginIssue>>;
+	) => Promise<ReadonlyArray<TrackerIssue>>;
 	readonly fetchIssueStatesByIds?: (
 		ids: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<PluginIssueState>>;
+	) => Promise<ReadonlyArray<TrackerIssueState>>;
 	readonly fetchRunContext?: (
 		issueId: string,
 		state: string,
-	) => Promise<PluginRunContextRaw | null>;
+	) => Promise<TrackerRunContextRaw | null>;
 	readonly dispose?: () => void | Promise<void>;
 }
 
@@ -68,11 +68,11 @@ export interface PluginTrackerClient {
 export interface TrackerPluginDefinition<TConfig = TrackerPluginConfig> {
 	readonly name: string;
 	readonly validateConfig?: (raw: TrackerPluginConfig) => TConfig | Promise<TConfig>;
-	readonly factory: (config: TConfig) => PluginTrackerClient | Promise<PluginTrackerClient>;
+	readonly factory: (config: TConfig) => TrackerPluginClient | Promise<TrackerPluginClient>;
 }
 
 /** Context object passed to each method in a defineTracker definition. */
-export interface PluginContext<TConfig = TrackerPluginConfig> {
+export interface TrackerContext<TConfig = TrackerPluginConfig> {
 	readonly config: TConfig;
 	readonly states: {
 		readonly dispatch: ReadonlyArray<string>;
@@ -85,24 +85,24 @@ export interface PluginContext<TConfig = TrackerPluginConfig> {
 export interface TrackerDefinition<TConfig = TrackerPluginConfig, TSetup = unknown> {
 	readonly name: string;
 	readonly config?: (raw: TrackerPluginConfig) => TConfig | Promise<TConfig>;
-	readonly setup?: (ctx: PluginContext<TConfig>) => TSetup | Promise<TSetup>;
+	readonly setup?: (ctx: TrackerContext<TConfig>) => TSetup | Promise<TSetup>;
 	readonly fetchCandidateIssues: (
-		ctx: PluginContext<TConfig> & TSetup,
+		ctx: TrackerContext<TConfig> & TSetup,
 		dispatchStates: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<PluginIssue>>;
+	) => Promise<ReadonlyArray<TrackerIssue>>;
 	readonly fetchIssuesByStates?: (
-		ctx: PluginContext<TConfig> & TSetup,
+		ctx: TrackerContext<TConfig> & TSetup,
 		states: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<PluginIssue>>;
+	) => Promise<ReadonlyArray<TrackerIssue>>;
 	readonly fetchIssueStatesByIds?: (
-		ctx: PluginContext<TConfig> & TSetup,
+		ctx: TrackerContext<TConfig> & TSetup,
 		ids: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<PluginIssueState>>;
+	) => Promise<ReadonlyArray<TrackerIssueState>>;
 	readonly fetchRunContext?: (
-		ctx: PluginContext<TConfig> & TSetup,
+		ctx: TrackerContext<TConfig> & TSetup,
 		issueId: string,
 		state: string,
-	) => Promise<PluginRunContextRaw | null>;
+	) => Promise<TrackerRunContextRaw | null>;
 	readonly dispose?: () => void | Promise<void>;
 }
 
@@ -115,7 +115,7 @@ export function defineTracker<TConfig = TrackerPluginConfig, TSetup = unknown>(
 		validateConfig: definition.config,
 		async factory(config: TConfig) {
 			const pluginConfig = config as TrackerPluginConfig & TConfig;
-			const baseCtx: PluginContext<TConfig> = {
+			const baseCtx: TrackerContext<TConfig> = {
 				config,
 				states: {
 					dispatch: (pluginConfig as any).dispatchStates ?? (pluginConfig as any).dispatch_states ?? [],
@@ -124,7 +124,7 @@ export function defineTracker<TConfig = TrackerPluginConfig, TSetup = unknown>(
 				},
 			};
 			const setupResult = definition.setup ? await Promise.resolve(definition.setup(baseCtx)) : ({} as TSetup);
-			const ctx = { ...baseCtx, ...setupResult } as PluginContext<TConfig> & TSetup;
+			const ctx = { ...baseCtx, ...setupResult } as TrackerContext<TConfig> & TSetup;
 			return {
 				fetchCandidateIssues: (dispatchStates) => definition.fetchCandidateIssues(ctx, dispatchStates),
 				fetchIssuesByStates: definition.fetchIssuesByStates

--- a/packages/sdk/src/plugin/types.ts
+++ b/packages/sdk/src/plugin/types.ts
@@ -1,5 +1,5 @@
 /** Issue shape returned by tracker plugin methods. */
-export interface IssueLike {
+export interface PluginIssue {
 	readonly id: string;
 	readonly identifier: string;
 	readonly title: string;
@@ -23,22 +23,15 @@ export interface IssueLike {
 }
 
 /** Minimal issue state entry returned by fetchIssueStatesByIds. */
-export interface IssueStateEntryLike {
+export interface PluginIssueState {
 	readonly id: string;
 	readonly state: string;
 }
 
-/** Run context returned by fetchRunContext — provides the workpad and review feedback. */
-export interface TrackerRunContextLike {
-	readonly raw: string | null;
-	readonly promptContext: string | null;
+/** Raw run context returned by plugin fetchRunContext — the orchestrator parses sections. */
+export interface PluginRunContextRaw {
 	readonly workpad: string | null;
-	readonly reviewFeedback: string | null;
-	readonly workpadSections: ReadonlyArray<{
-		readonly title: string;
-		readonly body: string;
-		readonly itemCount: number;
-	}>;
+	readonly reviewFeedback?: string | null;
 }
 
 /** Raw tracker config from the WORKFLOW.md frontmatter. */
@@ -54,25 +47,97 @@ export interface TrackerPluginConfig {
 }
 
 /** Client interface a tracker plugin must implement. */
-export interface PlainTrackerClient {
+export interface PluginTrackerClient {
 	readonly fetchCandidateIssues: (
 		dispatchStates: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<IssueLike>>;
+	) => Promise<ReadonlyArray<PluginIssue>>;
 	readonly fetchIssuesByStates?: (
 		states: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<IssueLike>>;
+	) => Promise<ReadonlyArray<PluginIssue>>;
 	readonly fetchIssueStatesByIds?: (
 		ids: ReadonlyArray<string>,
-	) => Promise<ReadonlyArray<IssueStateEntryLike>>;
+	) => Promise<ReadonlyArray<PluginIssueState>>;
 	readonly fetchRunContext?: (
 		issueId: string,
 		state: string,
-	) => Promise<TrackerRunContextLike | null>;
+	) => Promise<PluginRunContextRaw | null>;
+	readonly dispose?: () => void | Promise<void>;
 }
 
 /** Default export shape for a tracker plugin file. */
 export interface TrackerPluginDefinition<TConfig = TrackerPluginConfig> {
 	readonly name: string;
 	readonly validateConfig?: (raw: TrackerPluginConfig) => TConfig | Promise<TConfig>;
-	readonly factory: (config: TConfig) => PlainTrackerClient | Promise<PlainTrackerClient>;
+	readonly factory: (config: TConfig) => PluginTrackerClient | Promise<PluginTrackerClient>;
+}
+
+/** Context object passed to each method in a defineTracker definition. */
+export interface PluginContext<TConfig = TrackerPluginConfig> {
+	readonly config: TConfig;
+	readonly states: {
+		readonly dispatch: ReadonlyArray<string>;
+		readonly parked: ReadonlyArray<string>;
+		readonly terminal: ReadonlyArray<string>;
+	};
+}
+
+/** Shape passed to defineTracker — declarative tracker plugin definition. */
+export interface TrackerDefinition<TConfig = TrackerPluginConfig, TSetup = unknown> {
+	readonly name: string;
+	readonly config?: (raw: TrackerPluginConfig) => TConfig | Promise<TConfig>;
+	readonly setup?: (ctx: PluginContext<TConfig>) => TSetup | Promise<TSetup>;
+	readonly fetchCandidateIssues: (
+		ctx: PluginContext<TConfig> & TSetup,
+		dispatchStates: ReadonlyArray<string>,
+	) => Promise<ReadonlyArray<PluginIssue>>;
+	readonly fetchIssuesByStates?: (
+		ctx: PluginContext<TConfig> & TSetup,
+		states: ReadonlyArray<string>,
+	) => Promise<ReadonlyArray<PluginIssue>>;
+	readonly fetchIssueStatesByIds?: (
+		ctx: PluginContext<TConfig> & TSetup,
+		ids: ReadonlyArray<string>,
+	) => Promise<ReadonlyArray<PluginIssueState>>;
+	readonly fetchRunContext?: (
+		ctx: PluginContext<TConfig> & TSetup,
+		issueId: string,
+		state: string,
+	) => Promise<PluginRunContextRaw | null>;
+	readonly dispose?: () => void | Promise<void>;
+}
+
+/** Factory for creating tracker plugins from a declarative definition. */
+export function defineTracker<TConfig = TrackerPluginConfig, TSetup = unknown>(
+	definition: TrackerDefinition<TConfig, TSetup>,
+): TrackerPluginDefinition<TConfig> {
+	return {
+		name: definition.name,
+		validateConfig: definition.config,
+		async factory(config: TConfig) {
+			const pluginConfig = config as TrackerPluginConfig & TConfig;
+			const baseCtx: PluginContext<TConfig> = {
+				config,
+				states: {
+					dispatch: (pluginConfig as any).dispatchStates ?? (pluginConfig as any).dispatch_states ?? [],
+					parked: (pluginConfig as any).parkedStates ?? (pluginConfig as any).parked_states ?? [],
+					terminal: (pluginConfig as any).terminalStates ?? (pluginConfig as any).terminal_states ?? [],
+				},
+			};
+			const setupResult = definition.setup ? await Promise.resolve(definition.setup(baseCtx)) : ({} as TSetup);
+			const ctx = { ...baseCtx, ...setupResult } as PluginContext<TConfig> & TSetup;
+			return {
+				fetchCandidateIssues: (dispatchStates) => definition.fetchCandidateIssues(ctx, dispatchStates),
+				fetchIssuesByStates: definition.fetchIssuesByStates
+					? (states) => definition.fetchIssuesByStates!(ctx, states)
+					: undefined,
+				fetchIssueStatesByIds: definition.fetchIssueStatesByIds
+					? (ids) => definition.fetchIssueStatesByIds!(ctx, ids)
+					: undefined,
+				fetchRunContext: definition.fetchRunContext
+					? (issueId, state) => definition.fetchRunContext!(ctx, issueId, state)
+					: undefined,
+				dispose: definition.dispose,
+			};
+		},
+	};
 }

--- a/packages/sdk/src/schemas/issue.ts
+++ b/packages/sdk/src/schemas/issue.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
-import type { PluginIssue } from "../plugin/types.js";
-import type { PluginIssueState } from "../plugin/types.js";
+import type { TrackerIssue } from "../plugin/types.js";
+import type { TrackerIssueState } from "../plugin/types.js";
 
 export class BlockerRef extends Schema.Class<BlockerRef>("BlockerRef")({
 	id: Schema.NullOr(Schema.String),
@@ -25,13 +25,13 @@ export class Issue extends Schema.Class<Issue>("Issue")({
 	updatedAt: Schema.NullOr(Schema.String),
 }) {}
 
-/** Compile-time proof: Issue fields must stay in sync with PluginIssue. */
-export type _IssueEncodedMatchesPluginIssue = typeof Issue.Encoded extends PluginIssue ? true : never;
+/** Compile-time proof: Issue fields must stay in sync with TrackerIssue. */
+export type _IssueEncodedMatchesTrackerIssue = typeof Issue.Encoded extends TrackerIssue ? true : never;
 
 export class IssueStateEntry extends Schema.Class<IssueStateEntry>("IssueStateEntry")({
 	id: Schema.String,
 	state: Schema.String,
 }) {}
 
-/** Compile-time proof: IssueStateEntry fields must stay in sync with PluginIssueState. */
-export type _IssueStateEntryMatchesPluginIssueState = typeof IssueStateEntry.Encoded extends PluginIssueState ? true : never;
+/** Compile-time proof: IssueStateEntry fields must stay in sync with TrackerIssueState. */
+export type _IssueStateEntryMatchesTrackerIssueState = typeof IssueStateEntry.Encoded extends TrackerIssueState ? true : never;

--- a/packages/sdk/src/schemas/issue.ts
+++ b/packages/sdk/src/schemas/issue.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
-import type { IssueLike } from "../plugin/types.js";
-import type { IssueStateEntryLike } from "../plugin/types.js";
+import type { PluginIssue } from "../plugin/types.js";
+import type { PluginIssueState } from "../plugin/types.js";
 
 export class BlockerRef extends Schema.Class<BlockerRef>("BlockerRef")({
 	id: Schema.NullOr(Schema.String),
@@ -25,13 +25,13 @@ export class Issue extends Schema.Class<Issue>("Issue")({
 	updatedAt: Schema.NullOr(Schema.String),
 }) {}
 
-/** Compile-time proof: Issue fields must stay in sync with IssueLike. */
-export type _IssueEncodedMatchesIssueLike = typeof Issue.Encoded extends IssueLike ? true : never;
+/** Compile-time proof: Issue fields must stay in sync with PluginIssue. */
+export type _IssueEncodedMatchesPluginIssue = typeof Issue.Encoded extends PluginIssue ? true : never;
 
 export class IssueStateEntry extends Schema.Class<IssueStateEntry>("IssueStateEntry")({
 	id: Schema.String,
 	state: Schema.String,
 }) {}
 
-/** Compile-time proof: IssueStateEntry fields must stay in sync with IssueStateEntryLike. */
-export type _IssueStateEntryMatchesLike = typeof IssueStateEntry.Encoded extends IssueStateEntryLike ? true : never;
+/** Compile-time proof: IssueStateEntry fields must stay in sync with PluginIssueState. */
+export type _IssueStateEntryMatchesPluginIssueState = typeof IssueStateEntry.Encoded extends PluginIssueState ? true : never;


### PR DESCRIPTION
## what

Breaking redesign of the `@plot/sdk` tracker plugin API.

### defineTracker factory

```ts
import { defineTracker } from "@plot/sdk";

export default defineTracker({
  name: "my-tracker",
  config(raw) {
    return { projectKey: raw.project_key as string };
  },
  async setup(ctx) {
    const client = await connectToApi(ctx.config.projectKey);
    return { client }; // merged into ctx for all methods
  },
  async fetchCandidateIssues(ctx, dispatchStates) {
    return ctx.client.getIssues(dispatchStates);
  },
  async fetchRunContext(ctx, issueId) {
    const workpad = await ctx.client.getWorkpad(issueId);
    return { workpad, reviewFeedback: null };
  },
});
```

### key changes

| before | after |
|--------|-------|
| `IssueLike` | `PluginIssue` |
| `IssueStateEntryLike` | `PluginIssueState` |
| `TrackerRunContextLike` | `PluginRunContextRaw` (raw text only) |
| `PlainTrackerClient` | `PluginTrackerClient` |
| `validateConfig` + `factory` | `config()` + `setup()` + methods |
| plugin parses workpad sections | orchestrator parses sections |

### setup() hook

Runs once during factory, returns shared resources merged into `ctx`. Solves the re-initialization problem where github/beads called `getAuthToken()` + `detectRepo()` in every method.

### simplified fetchRunContext

Plugins return `{ workpad: string | null; reviewFeedback?: string | null }` — raw text. The orchestrator calls `buildRunContext()` / `parseWorkpadSections()` itself. Plugins no longer need to know about markdown section structure.

### verified
- 47/47 tests pass
- SDK typecheck clean
- plot typecheck clean
- github + beads trackers migrated to defineTracker with setup()