### PR TITLE
#95: clarify release dry-run version requirements

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,6 +28,10 @@ plot-ai uses lockstep semver across the public npm surface.
 ```bash
 PLOT_VERSION=0.0.1 bun run release:build
 bun run release:smoke
-PLOT_CHANNEL=latest bun run release:publish:dry-run
+PLOT_VERSION=0.0.1 PLOT_CHANNEL=latest bun run release:publish:dry-run
 PLOT_VERSION=0.0.1 PLOT_CHANNEL=latest bun run release:publish
 ```
+
+`release:publish:dry-run` still asks npm to validate whether the package version can be published. If the version in `dist/release` was already published, npm rejects the dry-run with `You cannot publish over the previously published versions`.
+
+Use the same unpublished `PLOT_VERSION` for `release:build`, `release:publish:dry-run`, and `release:publish`. For local release validation, prefer an unpublished prerelease-style version such as `0.0.1-beta.0` with `PLOT_CHANNEL=beta` so you do not collide with an existing stable release.


### PR DESCRIPTION
## Summary

Clarifies that `release:publish:dry-run` must use the same unpublished
`PLOT_VERSION` used for the release build, because npm still validates
whether that version can be published.

## Changes

- update the dry-run example in `RELEASING.md` to include the same
  `PLOT_VERSION` as build and publish
- explain the npm version-collision failure and suggest using an
  unpublished prerelease-style version for local validation

## Verification

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] Tests pass (`bun run test`)
- [x] Build passes (`bun run build`)
- [x] Docs inspected (`sed -n '1,120p' RELEASING.md`)

## Issue

Resolves #95
