### PR TITLE
refactor(cli): use citty generated help

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,33 +1,144 @@
+import { DEFAULT_WORKFLOW_PATH } from "@plot/session/workflow";
 import type { ArgsDef } from "citty";
 
 export const commonArgs = {
-	workflow: { type: "string" },
-	"session-id": { type: "string" },
-	cwd: { type: "string" },
-	"plot-dir": { type: "string" },
-	"agent-dir": { type: "string" },
-	"session-dir": { type: "string" },
-	"log-level": { type: "string" },
-	"log-format": { type: "string" },
-	"request-queue-capacity": { type: "string" },
-	"event-capacity": { type: "string" },
-	"replay-capacity": { type: "string" },
-	"tick-interval-ms": { type: "string" },
-	"max-run-duration-ms": { type: "string" },
-	provider: { type: "string" },
-	model: { type: "string" },
-	"api-key": { type: "string" },
-	thinking: { type: "string" },
-	tools: { type: "string" },
-	"exclude-tools": { type: "string" },
-	"no-tools": { type: "boolean" },
-	"no-builtin-tools": { type: "boolean" },
-	approve: { type: "boolean" },
-	skill: { type: "string" },
-	"prompt-template": { type: "string" },
-	"no-skills": { type: "boolean" },
-	"no-prompt-templates": { type: "boolean" },
-	"no-context-files": { type: "boolean" },
-	"system-prompt": { type: "string" },
-	"append-system-prompt": { type: "string" },
+	workflow: {
+		type: "string",
+		description: `Workflow file. Default: ${DEFAULT_WORKFLOW_PATH}`,
+		valueHint: "path",
+	},
+	"session-id": {
+		type: "string",
+		description: "Stable Plot session id.",
+		valueHint: "id",
+	},
+	cwd: {
+		type: "string",
+		description: "Project root for workflow execution and Plot state.",
+		valueHint: "path",
+	},
+	"plot-dir": {
+		type: "string",
+		description: "Project-local Plot state directory.",
+		valueHint: "path",
+	},
+	"agent-dir": {
+		type: "string",
+		description: "Agent auth/model state directory.",
+		valueHint: "path",
+	},
+	"session-dir": {
+		type: "string",
+		description: "Plot session storage directory.",
+		valueHint: "path",
+	},
+	"log-level": {
+		type: "string",
+		description: "Log level: debug, info, warn, error.",
+		valueHint: "level",
+	},
+	"log-format": {
+		type: "string",
+		description: "Log format: text or json.",
+		valueHint: "format",
+	},
+	"request-queue-capacity": {
+		type: "string",
+		description: "Maximum queued protocol/control requests.",
+		valueHint: "count",
+	},
+	"event-capacity": {
+		type: "string",
+		description: "Maximum retained session events.",
+		valueHint: "count",
+	},
+	"replay-capacity": {
+		type: "string",
+		description: "Maximum protocol events available for replay.",
+		valueHint: "count",
+	},
+	"tick-interval-ms": {
+		type: "string",
+		description: "Scheduled tick cadence in milliseconds.",
+		valueHint: "ms",
+	},
+	"max-run-duration-ms": {
+		type: "string",
+		description: "Timeout for a single work run in milliseconds.",
+		valueHint: "ms",
+	},
+	provider: {
+		type: "string",
+		description: "Override workflow agent provider.",
+		valueHint: "id",
+	},
+	model: {
+		type: "string",
+		description: "Override workflow agent model.",
+		valueHint: "id",
+	},
+	"api-key": {
+		type: "string",
+		description: "Provider API key override.",
+		valueHint: "key",
+	},
+	thinking: {
+		type: "string",
+		description: "Thinking level when supported by the provider.",
+		valueHint: "level",
+	},
+	tools: {
+		type: "string",
+		description: "Comma-separated allowlist of tools for the agent session.",
+		valueHint: "list",
+	},
+	"exclude-tools": {
+		type: "string",
+		description: "Comma-separated tools to remove from the agent session.",
+		valueHint: "list",
+	},
+	"no-tools": {
+		type: "boolean",
+		description: "Disable all agent tools.",
+	},
+	"no-builtin-tools": {
+		type: "boolean",
+		description: "Disable built-in agent tools.",
+	},
+	approve: {
+		type: "boolean",
+		description: "Approve supported provider/tool prompts automatically.",
+	},
+	skill: {
+		type: "string",
+		description: "Additional skill path for the agent session.",
+		valueHint: "path",
+	},
+	"prompt-template": {
+		type: "string",
+		description: "Additional prompt template path.",
+		valueHint: "path",
+	},
+	"no-skills": {
+		type: "boolean",
+		description: "Disable workflow-declared skills.",
+	},
+	"no-prompt-templates": {
+		type: "boolean",
+		description: "Disable workflow-declared prompt templates.",
+	},
+	"no-context-files": {
+		type: "boolean",
+		description: "Do not load context files into the agent session.",
+	},
+	"system-prompt": {
+		type: "string",
+		description: "Replace the agent system prompt.",
+		valueHint: "text",
+	},
+	"append-system-prompt": {
+		type: "string",
+		description: "Append text to the agent system prompt.",
+		valueHint: "text",
+	},
 } satisfies ArgsDef;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,9 @@
-import { DEFAULT_WORKFLOW_PATH } from "@plot/session/workflow";
-import { defineCommand, runCommand as runCittyCommand } from "citty";
+import {
+	defineCommand,
+	renderUsage,
+	runCommand as runCittyCommand,
+	type CommandDef,
+} from "citty";
 import { getCliIo, setCliIo } from "./cli-context.js";
 import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
@@ -13,26 +17,26 @@ export const version = "0.0.0";
 export { processCliIo } from "./io.js";
 export type { PlotCliIo } from "./io.js";
 
+const subCommands = {
+	"list-models": listModelsCommand,
+	auth: authCommand,
+	docs: docsCommand,
+	run: runCommand,
+	tui: tuiCommand,
+	serve: serveCommand,
+};
+
 const rootCommand = defineCommand({
 	meta: {
 		name: "plot",
 		version,
-		description: "LLM that ticks()",
+		description: "A control plane for long-running coding agents.",
 	},
-	subCommands: {
-		"list-models": listModelsCommand,
-		auth: authCommand,
-		docs: docsCommand,
-		run: runCommand,
-		tui: tuiCommand,
-		serve: serveCommand,
-	},
-	run: ({ rawArgs }) => {
+	subCommands,
+	run: async ({ rawArgs }) => {
 		if (rawArgs.some((arg) => !arg.startsWith("-"))) return undefined;
 		const io = getCliIo();
-		return io.writeStdout(
-			`plot ${version}\nCommands: list-models, auth status|login|logout, docs, run, tui, serve stdio\nDefault workflow: ${DEFAULT_WORKFLOW_PATH}\n`,
-		);
+		await io.writeStdout(await renderUsage(rootCommand));
 	},
 });
 
@@ -40,10 +44,9 @@ export const runPlotCli = async (
 	args: readonly string[],
 	io: PlotCliIo = processCliIo(),
 ): Promise<void> => {
-	if (args[0] === "--help" || args[0] === "help") {
-		await io.writeStdout(
-			`plot ${version}\nCommands: list-models, auth status|login|logout, docs, run, tui, serve stdio\nDefault workflow: ${DEFAULT_WORKFLOW_PATH}\n`,
-		);
+	const help = await renderHelp(args);
+	if (help !== undefined) {
+		await io.writeStdout(help);
 		return;
 	}
 	setCliIo(io);
@@ -56,3 +59,16 @@ export const runPlotCli = async (
 export const makePlotCommand = (_io: PlotCliIo = processCliIo()) => ({
 	version,
 });
+
+const topLevelCommands = subCommands as unknown as Record<string, CommandDef>;
+
+const renderHelp = async (args: readonly string[]) => {
+	if (args[0] === "--help" || args[0] === "help") {
+		return renderUsage(rootCommand);
+	}
+	const [command] = args;
+	if (command === undefined || !args.includes("--help")) return undefined;
+	const subCommand = topLevelCommands[command];
+	if (subCommand === undefined) return undefined;
+	return renderUsage(subCommand, rootCommand);
+};

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -15,11 +15,26 @@ const readPrompt = (message: string): Promise<string> => {
 };
 
 export const authCommand = defineCommand({
-	meta: { name: "auth", description: "Manage provider auth" },
-	args: commonArgs,
+	meta: {
+		name: "auth",
+		description: "Manage provider authentication.",
+	},
+	args: {
+		action: {
+			type: "positional",
+			description: "status, login, or logout.",
+			required: false,
+		},
+		providerName: {
+			type: "positional",
+			description: "Provider id from `plot list-models`.",
+			required: false,
+		},
+		...commonArgs,
+	},
 	run: ({ args }) => {
 		const io = getCliIo();
-		const [sub] = args._;
+		const sub = typeof args.action === "string" ? args.action : args._[0];
 		const cwd = str(args, "cwd") ?? process.cwd();
 		const plotDir = str(args, "plot-dir");
 		const agentDir = str(args, "agent-dir");
@@ -28,7 +43,9 @@ export const authCommand = defineCommand({
 			...(plotDir === undefined ? {} : { plotDir }),
 			...(agentDir === undefined ? {} : { agentDir }),
 		});
-		const provider = args._[1] ?? str(args, "provider");
+		const provider =
+			(typeof args.providerName === "string" ? args.providerName : args._[1]) ??
+			str(args, "provider");
 		if (sub === "status")
 			return runHumanCommand(
 				io,

--- a/packages/cli/src/commands/list-models.ts
+++ b/packages/cli/src/commands/list-models.ts
@@ -6,12 +6,22 @@ import { makeAuth, str } from "../options.js";
 import { renderModels } from "../render.js";
 
 export const listModelsCommand = defineCommand({
-	meta: { name: "list-models", description: "List available models" },
-	args: commonArgs,
+	meta: {
+		name: "list-models",
+		description: "List models visible to Plot auth.",
+	},
+	args: {
+		search: {
+			type: "positional",
+			description: "Optional provider/model search text.",
+			required: false,
+		},
+		...commonArgs,
+	},
 	run: ({ args }) => {
 		const io = getCliIo();
 		const cwd = str(args, "cwd") ?? process.cwd();
-		const search = args._[0];
+		const search = typeof args.search === "string" ? args.search : args._[0];
 		const plotDir = str(args, "plot-dir");
 		const agentDir = str(args, "agent-dir");
 		return runHumanCommand(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -7,7 +7,10 @@ import { renderRunEvent } from "../render.js";
 import { runDaemon } from "../runtime.js";
 
 export const runCommand = defineCommand({
-	meta: { name: "run", description: "Run Plot daemon" },
+	meta: {
+		name: "run",
+		description: "Run a workflow without opening the dashboard.",
+	},
 	args: commonArgs,
 	async run({ args }) {
 		const io = getCliIo();

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -5,11 +5,21 @@ import { baseOptions } from "../options.js";
 import { serveStdio } from "../runtime.js";
 
 export const serveCommand = defineCommand({
-	meta: { name: "serve", description: "Serve Plot protocol" },
-	args: commonArgs,
+	meta: {
+		name: "serve",
+		description: "Serve the plot.v1 protocol for automation.",
+	},
+	args: {
+		transport: {
+			type: "positional",
+			description: "Transport to serve. Currently only `stdio`.",
+			required: false,
+		},
+		...commonArgs,
+	},
 	run: ({ args }) => {
 		const io = getCliIo();
-		const [sub] = args._;
+		const sub = typeof args.transport === "string" ? args.transport : args._[0];
 		if (sub !== "stdio") throw new Error("usage: plot serve stdio");
 		return serveStdio({
 			...baseOptions(args),

--- a/packages/cli/src/commands/tui.ts
+++ b/packages/cli/src/commands/tui.ts
@@ -5,7 +5,10 @@ import { getCliIo } from "../cli-context.js";
 import { baseOptions } from "../options.js";
 
 export const tuiCommand = defineCommand({
-	meta: { name: "tui", description: "Run Plot TUI" },
+	meta: {
+		name: "tui",
+		description: "Open the terminal dashboard for a workflow.",
+	},
 	args: commonArgs,
 	run: ({ args }) => {
 		const io = getCliIo();

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -102,6 +102,37 @@ describe("plot CLI", () => {
 		expect(output).toContain("faux-1");
 	});
 
+	test("prints citty root help", async () => {
+		const stdout: string[] = [];
+		await runPlotCli(["--help"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+		});
+
+		const output = stdout.join("");
+		expect(output).toContain("A control plane for long-running coding agents.");
+		expect(output).toContain("list-models");
+		expect(output).toContain("docs");
+		expect(output).toContain("run");
+	});
+
+	test("prints citty subcommand help", async () => {
+		const stdout: string[] = [];
+		await runPlotCli(["run", "--help"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+		});
+
+		const output = stdout.join("");
+		expect(output).toContain("Run a workflow without opening the dashboard.");
+		expect(output).toContain("--workflow");
+		expect(output).toContain("--provider");
+	});
+
 	test("prints bundled extension author docs", async () => {
 		const stdout: string[] = [];
 		await runPlotCli(["docs", "extension-prompt"], {


### PR DESCRIPTION
## Summary
- use citty's renderUsage for root and subcommand help instead of hand-rolled help text
- enrich command metadata and argument descriptions/value hints
- add positional args for auth/list-models/serve so generated help is useful
- cover root and subcommand help in CLI tests

## Verification
- bun run check