### PR TITLE
refactor(cli): model nested citty commands

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_WORKFLOW_PATH } from "@plot/session/workflow";
 import type { ArgsDef } from "citty";
 
-export const commonArgs = {
+export const workflowArgs = {
 	workflow: {
 		type: "string",
 		description: `Workflow file. Default: ${DEFAULT_WORKFLOW_PATH}`,
@@ -12,6 +12,9 @@ export const commonArgs = {
 		description: "Stable Plot session id.",
 		valueHint: "id",
 	},
+} satisfies ArgsDef;
+
+export const pathArgs = {
 	cwd: {
 		type: "string",
 		description: "Project root for workflow execution and Plot state.",
@@ -32,6 +35,15 @@ export const commonArgs = {
 		description: "Plot session storage directory.",
 		valueHint: "path",
 	},
+} satisfies ArgsDef;
+
+export const authPathArgs = {
+	cwd: pathArgs.cwd,
+	"plot-dir": pathArgs["plot-dir"],
+	"agent-dir": pathArgs["agent-dir"],
+} satisfies ArgsDef;
+
+export const loggingArgs = {
 	"log-level": {
 		type: "string",
 		description: "Log level: debug, info, warn, error.",
@@ -42,6 +54,9 @@ export const commonArgs = {
 		description: "Log format: text or json.",
 		valueHint: "format",
 	},
+} satisfies ArgsDef;
+
+export const runtimeArgs = {
 	"request-queue-capacity": {
 		type: "string",
 		description: "Maximum queued protocol/control requests.",
@@ -67,6 +82,9 @@ export const commonArgs = {
 		description: "Timeout for a single work run in milliseconds.",
 		valueHint: "ms",
 	},
+} satisfies ArgsDef;
+
+export const agentOverrideArgs = {
 	provider: {
 		type: "string",
 		description: "Override workflow agent provider.",
@@ -109,6 +127,9 @@ export const commonArgs = {
 		type: "boolean",
 		description: "Approve supported provider/tool prompts automatically.",
 	},
+} satisfies ArgsDef;
+
+export const resourceArgs = {
 	skill: {
 		type: "string",
 		description: "Additional skill path for the agent session.",
@@ -141,4 +162,13 @@ export const commonArgs = {
 		description: "Append text to the agent system prompt.",
 		valueHint: "text",
 	},
+} satisfies ArgsDef;
+
+export const sessionCommandArgs = {
+	...workflowArgs,
+	...pathArgs,
+	...loggingArgs,
+	...runtimeArgs,
+	...agentOverrideArgs,
+	...resourceArgs,
 } satisfies ArgsDef;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -60,15 +60,22 @@ export const makePlotCommand = (_io: PlotCliIo = processCliIo()) => ({
 	version,
 });
 
-const topLevelCommands = subCommands as unknown as Record<string, CommandDef>;
+const commandChildren = (command: CommandDef): Record<string, CommandDef> =>
+	(command.subCommands ?? {}) as Record<string, CommandDef>;
 
 const renderHelp = async (args: readonly string[]) => {
 	if (args[0] === "--help" || args[0] === "help") {
 		return renderUsage(rootCommand);
 	}
-	const [command] = args;
-	if (command === undefined || !args.includes("--help")) return undefined;
-	const subCommand = topLevelCommands[command];
-	if (subCommand === undefined) return undefined;
-	return renderUsage(subCommand, rootCommand);
+	if (!args.includes("--help") && !args.includes("-h")) return undefined;
+	let command: CommandDef = rootCommand;
+	let parent: CommandDef | undefined;
+	for (const arg of args) {
+		if (arg.startsWith("-")) continue;
+		const child = commandChildren(command)[arg];
+		if (child === undefined) break;
+		parent = command;
+		command = child;
+	}
+	return renderUsage(command, parent);
 };

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,6 +1,6 @@
 import { createInterface } from "node:readline/promises";
 import { defineCommand } from "citty";
-import { commonArgs } from "../args.js";
+import { authPathArgs } from "../args.js";
 import { getCliIo } from "../cli-context.js";
 import { runHumanCommand, writeProcessStderr } from "../io.js";
 import { makeAuth, str } from "../options.js";
@@ -14,92 +14,130 @@ const readPrompt = (message: string): Promise<string> => {
 	return readline.question(`${message} `).finally(() => readline.close());
 };
 
+const providerArg = {
+	providerName: {
+		type: "positional",
+		description: "Provider id from `plot list-models`.",
+		required: true,
+	},
+} as const;
+
+const optionalProviderArg = {
+	providerName: {
+		type: "positional",
+		description: "Optional provider id from `plot list-models`.",
+		required: false,
+	},
+} as const;
+
+const makeAuthFromArgs = (args: Record<string, unknown>) => {
+	const cwd = str(args, "cwd") ?? process.cwd();
+	const plotDir = str(args, "plot-dir");
+	const agentDir = str(args, "agent-dir");
+	return makeAuth({
+		cwd,
+		...(plotDir === undefined ? {} : { plotDir }),
+		...(agentDir === undefined ? {} : { agentDir }),
+	});
+};
+
 export const authCommand = defineCommand({
 	meta: {
 		name: "auth",
 		description: "Manage provider authentication.",
 	},
-	args: {
-		action: {
-			type: "positional",
-			description: "status, login, or logout.",
-			required: false,
-		},
-		providerName: {
-			type: "positional",
-			description: "Provider id from `plot list-models`.",
-			required: false,
-		},
-		...commonArgs,
-	},
-	run: ({ args }) => {
-		const io = getCliIo();
-		const sub = typeof args.action === "string" ? args.action : args._[0];
-		const cwd = str(args, "cwd") ?? process.cwd();
-		const plotDir = str(args, "plot-dir");
-		const agentDir = str(args, "agent-dir");
-		const auth = makeAuth({
-			cwd,
-			...(plotDir === undefined ? {} : { plotDir }),
-			...(agentDir === undefined ? {} : { agentDir }),
-		});
-		const provider =
-			(typeof args.providerName === "string" ? args.providerName : args._[1]) ??
-			str(args, "provider");
-		if (sub === "status")
-			return runHumanCommand(
-				io,
-				auth.status(provider),
-				renderAuthStatus,
-				"Pass a provider id from `plot list-models`.",
-			);
-		if (sub === "logout" && provider)
-			return runHumanCommand(
-				io,
-				auth.logout(provider).then(() => provider),
-				(x) => `Logged out from ${x}.\n`,
-				"Pass a valid provider id from `plot list-models`.",
-			);
-		if (sub === "login" && provider)
-			return runHumanCommand(
-				io,
-				auth
-					.login({
-						provider,
-						events: {
-							auth: (info) => {
-								void writeProcessStderr(
-									`Open URL: ${info.url}\n${info.instructions ?? ""}\n`,
-								);
+	subCommands: {
+		status: defineCommand({
+			meta: {
+				name: "status",
+				description: "Show provider authentication status.",
+			},
+			args: {
+				...optionalProviderArg,
+				...authPathArgs,
+			},
+			run: ({ args }) => {
+				const provider = str(args, "providerName");
+				return runHumanCommand(
+					getCliIo(),
+					makeAuthFromArgs(args).status(provider),
+					renderAuthStatus,
+					"Pass a provider id from `plot list-models`.",
+				);
+			},
+		}),
+		login: defineCommand({
+			meta: {
+				name: "login",
+				description: "Start an interactive provider login.",
+			},
+			args: {
+				...providerArg,
+				...authPathArgs,
+			},
+			run: ({ args }) => {
+				const provider = str(args, "providerName")!;
+				return runHumanCommand(
+					getCliIo(),
+					makeAuthFromArgs(args)
+						.login({
+							provider,
+							events: {
+								auth: (info) => {
+									void writeProcessStderr(
+										`Open URL: ${info.url}\n${info.instructions ?? ""}\n`,
+									);
+								},
+								deviceCode: (info) => {
+									void writeProcessStderr(
+										`Open ${info.verificationUri} and enter ${info.userCode}\n`,
+									);
+								},
+								prompt: (prompt) => {
+									void writeProcessStderr(`${prompt.message}\n`);
+								},
+								select: (prompt) => {
+									void writeProcessStderr(
+										`${prompt.message}: ${prompt.options.map((o) => o.label).join(", ")}\n`,
+									);
+								},
+								progress: (message) => {
+									void writeProcessStderr(`${message}\n`);
+								},
 							},
-							deviceCode: (info) => {
-								void writeProcessStderr(
-									`Open ${info.verificationUri} and enter ${info.userCode}\n`,
-								);
-							},
-							prompt: (prompt) => {
-								void writeProcessStderr(`${prompt.message}\n`);
-							},
-							select: (prompt) => {
-								void writeProcessStderr(
-									`${prompt.message}: ${prompt.options.map((o) => o.label).join(", ")}\n`,
-								);
-							},
-							progress: (message) => {
-								void writeProcessStderr(`${message}\n`);
-							},
-						},
-						promptInput: (prompt) => readPrompt(prompt.message),
-						manualCodeInput: () =>
-							readPrompt("Paste the authorization code or redirect URL:"),
-						selectInput: async (prompt) =>
-							(await readPrompt(prompt.message)).trim() ||
-							prompt.options[0]?.id,
-					})
-					.then(() => provider),
-				(x) => `Logged in to ${x}.\n`,
-				"Run in an interactive terminal or use the protocol auth_login command with promptResponses.",
-			);
-		throw new Error("usage: plot auth status|login|logout [provider]");
+							promptInput: (prompt) => readPrompt(prompt.message),
+							manualCodeInput: () =>
+								readPrompt("Paste the authorization code or redirect URL:"),
+							selectInput: async (prompt) =>
+								(await readPrompt(prompt.message)).trim() ||
+								prompt.options[0]?.id,
+						})
+						.then(() => provider),
+					(x) => `Logged in to ${x}.\n`,
+					"Run in an interactive terminal or use the protocol auth_login command with promptResponses.",
+				);
+			},
+		}),
+		logout: defineCommand({
+			meta: {
+				name: "logout",
+				description: "Remove stored authentication for a provider.",
+			},
+			args: {
+				...providerArg,
+				...authPathArgs,
+			},
+			run: ({ args }) => {
+				const provider = str(args, "providerName")!;
+				return runHumanCommand(
+					getCliIo(),
+					makeAuthFromArgs(args)
+						.logout(provider)
+						.then(() => provider),
+					(x) => `Logged out from ${x}.\n`,
+					"Pass a valid provider id from `plot list-models`.",
+				);
+			},
+		}),
 	},
 });

--- a/packages/cli/src/commands/list-models.ts
+++ b/packages/cli/src/commands/list-models.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { commonArgs } from "../args.js";
+import { authPathArgs } from "../args.js";
 import { getCliIo } from "../cli-context.js";
 import { runHumanCommand } from "../io.js";
 import { makeAuth, str } from "../options.js";
@@ -16,7 +16,7 @@ export const listModelsCommand = defineCommand({
 			description: "Optional provider/model search text.",
 			required: false,
 		},
-		...commonArgs,
+		...authPathArgs,
 	},
 	run: ({ args }) => {
 		const io = getCliIo();

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { commonArgs } from "../args.js";
+import { sessionCommandArgs } from "../args.js";
 import { getCliIo } from "../cli-context.js";
 import { errorMessage, writeCliStderr } from "../io.js";
 import { baseOptions } from "../options.js";
@@ -11,7 +11,7 @@ export const runCommand = defineCommand({
 		name: "run",
 		description: "Run a workflow without opening the dashboard.",
 	},
-	args: commonArgs,
+	args: sessionCommandArgs,
 	async run({ args }) {
 		const io = getCliIo();
 		try {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { commonArgs } from "../args.js";
+import { sessionCommandArgs } from "../args.js";
 import { getCliIo } from "../cli-context.js";
 import { baseOptions } from "../options.js";
 import { serveStdio } from "../runtime.js";
@@ -9,25 +9,24 @@ export const serveCommand = defineCommand({
 		name: "serve",
 		description: "Serve the plot.v1 protocol for automation.",
 	},
-	args: {
-		transport: {
-			type: "positional",
-			description: "Transport to serve. Currently only `stdio`.",
-			required: false,
-		},
-		...commonArgs,
-	},
-	run: ({ args }) => {
-		const io = getCliIo();
-		const sub = typeof args.transport === "string" ? args.transport : args._[0];
-		if (sub !== "stdio") throw new Error("usage: plot serve stdio");
-		return serveStdio({
-			...baseOptions(args),
-			...(io.createAgentSession === undefined
-				? {}
-				: { createAgentSession: io.createAgentSession }),
-			stdin: io.stdin,
-			writeStdout: io.writeStdout,
-		});
+	subCommands: {
+		stdio: defineCommand({
+			meta: {
+				name: "stdio",
+				description: "Serve plot.v1 over newline-delimited JSON on stdio.",
+			},
+			args: sessionCommandArgs,
+			run: ({ args }) => {
+				const io = getCliIo();
+				return serveStdio({
+					...baseOptions(args),
+					...(io.createAgentSession === undefined
+						? {}
+						: { createAgentSession: io.createAgentSession }),
+					stdin: io.stdin,
+					writeStdout: io.writeStdout,
+				});
+			},
+		}),
 	},
 });

--- a/packages/cli/src/commands/tui.ts
+++ b/packages/cli/src/commands/tui.ts
@@ -1,6 +1,6 @@
 import { runPlotTui } from "@plot/tui/plot-tui";
 import { defineCommand } from "citty";
-import { commonArgs } from "../args.js";
+import { sessionCommandArgs } from "../args.js";
 import { getCliIo } from "../cli-context.js";
 import { baseOptions } from "../options.js";
 
@@ -9,7 +9,7 @@ export const tuiCommand = defineCommand({
 		name: "tui",
 		description: "Open the terminal dashboard for a workflow.",
 	},
-	args: commonArgs,
+	args: sessionCommandArgs,
 	run: ({ args }) => {
 		const io = getCliIo();
 		return runPlotTui({

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -4,17 +4,25 @@ import type { PlotAgentSessionCliOverrides } from "@plot/session/pi-agent-sessio
 import type { ParsedArgs } from "citty";
 import type { LogFormat, LogLevelFlag } from "./runtime.js";
 
-export const str = (args: ParsedArgs, name: string): string | undefined => {
+export const str = (
+	args: Record<string, unknown>,
+	name: string,
+): string | undefined => {
 	const v = args[name];
 	return typeof v === "string" ? v : undefined;
 };
-export const bool = (args: ParsedArgs, name: string): boolean | undefined =>
-	args[name] === true ? true : undefined;
+export const bool = (
+	args: Record<string, unknown>,
+	name: string,
+): boolean | undefined => (args[name] === true ? true : undefined);
 export const int = (args: ParsedArgs, name: string): number | undefined => {
 	const v = str(args, name);
 	return v === undefined ? undefined : Number.parseInt(v, 10);
 };
-export const many = (args: ParsedArgs, name: string): readonly string[] => {
+export const many = (
+	args: Record<string, unknown>,
+	name: string,
+): readonly string[] => {
 	const v = args[name];
 	return Array.isArray(v) ? v : typeof v === "string" ? [v] : [];
 };

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -133,6 +133,55 @@ describe("plot CLI", () => {
 		expect(output).toContain("--provider");
 	});
 
+	test("prints nested citty auth help", async () => {
+		const stdout: string[] = [];
+		await runPlotCli(["auth", "login", "--help"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+		});
+
+		const output = stdout.join("");
+		expect(output).toContain("Start an interactive provider login.");
+		expect(output).toContain("PROVIDERNAME");
+		expect(output).toContain("--agent-dir");
+		expect(output).not.toContain("--tick-interval-ms");
+	});
+
+	test("prints nested citty serve help", async () => {
+		const stdout: string[] = [];
+		await runPlotCli(["serve", "stdio", "--help"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+		});
+
+		const output = stdout.join("");
+		expect(output).toContain(
+			"Serve plot.v1 over newline-delimited JSON on stdio.",
+		);
+		expect(output).toContain("--workflow");
+		expect(output).toContain("--tick-interval-ms");
+	});
+
+	test("list-models help only exposes auth path options", async () => {
+		const stdout: string[] = [];
+		await runPlotCli(["list-models", "--help"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+		});
+
+		const output = stdout.join("");
+		expect(output).toContain("Optional provider/model search text.");
+		expect(output).toContain("--agent-dir");
+		expect(output).not.toContain("--tick-interval-ms");
+		expect(output).not.toContain("--workflow");
+	});
+
 	test("prints bundled extension author docs", async () => {
 		const stdout: string[] = [];
 		await runPlotCli(["docs", "extension-prompt"], {


### PR DESCRIPTION
## Summary
- model auth status/login/logout and serve stdio as nested citty subcommands
- split broad CLI args into focused groups so commands only expose relevant options
- keep protocol serving stdout-clean while generated nested help remains available
- add coverage for nested auth/serve help and reduced list-models options

## Verification
- bun run check