### PR TITLE
fix(example): use public Plot SDK import

### DIFF
--- a/examples/pr-review/README.md
+++ b/examples/pr-review/README.md
@@ -12,10 +12,11 @@ The agent is expected to use normal tools (`bash`, `git`, `gh`, `rg`, tests) and
 
 ## Use
 
-Install Plot via the `plot-ai` package, then run this workflow from the repository root you want reviewed.
+Install Plot via the `plot-ai` package, then install this example's extension dependency. The example imports the public SDK from `plot-ai/sdk`, just like a real external extension.
 
 ```bash
 npm install -g plot-ai
+npm install --prefix examples/pr-review
 plot run --workflow examples/pr-review/WORKFLOW.md
 ```
 

--- a/examples/pr-review/github-pr-reviewer.extension.ts
+++ b/examples/pr-review/github-pr-reviewer.extension.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { definePlotExtension } from "../../packages/session/src/extension.js";
+import { definePlotExtension } from "plot-ai/sdk";
 import type { PlotExtensionWork } from "../../packages/session/src/extension.js";
 
 const execFileAsync = promisify(execFile);

--- a/examples/pr-review/package.json
+++ b/examples/pr-review/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "plot-pr-review-example",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"plot-ai": "latest"
+	}
+}

--- a/scripts/check-lockfile-commit.mjs
+++ b/scripts/check-lockfile-commit.mjs
@@ -7,7 +7,9 @@ const staged = git(["diff", "--cached", "--name-only"])
 	.map((line) => line.trim())
 	.filter(Boolean);
 
-const packageFiles = staged.filter((file) => file.endsWith("package.json"));
+const packageFiles = staged.filter(
+	(file) => file.endsWith("package.json") && isRootLockfileManaged(file),
+);
 const lockChanged = staged.includes("bun.lock");
 
 const packageDependencyChanged = packageFiles.some((file) =>
@@ -20,6 +22,12 @@ if (packageDependencyChanged && !lockChanged) {
 		"Run `bun install` and stage bun.lock, or stage bun.lock if already updated.",
 	);
 	process.exit(1);
+}
+
+function isRootLockfileManaged(file) {
+	return (
+		file === "package.json" || /^packages\/[^/]+\/package\.json$/.test(file)
+	);
 }
 
 function dependencyShapeChanged(file) {


### PR DESCRIPTION
## Summary
- make the PR review example import definePlotExtension from plot-ai/sdk
- add an example-local package.json so the example behaves like a real external extension package
- document installing the example dependency before running the workflow
- keep root lockfile enforcement scoped to root-managed workspace packages

## Why
The example previously imported Plot internals from packages/session/src/extension.js. A packaged/local-release CLI then tried to load workspace source and failed resolving @plot/sdk outside the monorepo workspace.

## Verification
- bun run lint