### PR TITLE
fix(session): resolve public SDK imports in extensions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "@plot/sdk": "workspace:*",
         "better-result": "^2.9.2",
         "eta": "4.6.0",
+        "jiti": "^2.7.0",
         "yaml": "2.9.0",
       },
       "devDependencies": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -34,6 +34,7 @@
 		"@plot/sdk": "workspace:*",
 		"better-result": "^2.9.2",
 		"eta": "4.6.0",
+		"jiti": "^2.7.0",
 		"yaml": "2.9.0"
 	},
 	"devDependencies": {

--- a/packages/session/src/extension-source.ts
+++ b/packages/session/src/extension-source.ts
@@ -1,4 +1,4 @@
-import { pathToFileURL } from "node:url";
+import { createJiti } from "jiti/static";
 import { dirname, isAbsolute, resolve } from "node:path";
 import {
 	interruptWork,
@@ -22,6 +22,7 @@ import type {
 	PlotExtensionRuntime,
 	PlotExtensionWork,
 } from "./extension.js";
+import * as plotSdk from "@plot/sdk";
 
 export class PlotExtensionSourceError extends TaggedError(
 	"PlotExtensionSourceError",
@@ -256,6 +257,20 @@ export const makePlotExtensionSourceBundle = (options: {
 		},
 	};
 };
+const extensionVirtualModules: Record<string, unknown> = {
+	"plot-ai/sdk": plotSdk,
+	"@plot/sdk": plotSdk,
+};
+
+const importExtensionModule = async (source: string): Promise<unknown> => {
+	const jiti = createJiti(import.meta.url, {
+		moduleCache: false,
+		tryNative: false,
+		virtualModules: extensionVirtualModules,
+	});
+	return jiti.import(source);
+};
+
 const getModuleExtension = (module: unknown): PlotExtension | undefined => {
 	if (!isObjectRecord(module)) return undefined;
 	const candidate = module["default"] ?? module["extension"];
@@ -293,7 +308,7 @@ export const loadPlotExtensionRuntimeFromWorkflow = async (options: {
 	});
 	let module: unknown;
 	try {
-		module = await import(pathToFileURL(source).href);
+		module = await importExtensionModule(source);
 	} catch (error) {
 		throw new PlotExtensionSourceError({
 			phase: "load",

--- a/packages/session/test/extension-source.test.ts
+++ b/packages/session/test/extension-source.test.ts
@@ -200,6 +200,35 @@ describe("Plot extension source adapter", () => {
 		expect(interrupted).toEqual(["github:acme/web:pr:42:sha-1"]);
 	});
 
+	test("loads a local extension module that imports the public SDK", async () => {
+		const dir = await makeTempDir();
+		const extensionPath = join(dir, "extension.ts");
+		await writeFile(
+			extensionPath,
+			`import { definePlotExtension } from "plot-ai/sdk";
+export default definePlotExtension({
+  id: "public-sdk-test",
+  create: ({ work }) => ({
+    discover: () => [work({ id: "work:from-sdk", version: "v1" })]
+  })
+});
+`,
+		);
+		const loaded = await loadPlotExtensionRuntimeFromWorkflow({
+			paths: { ...paths, cwd: dir },
+			workflow: {
+				...workflow,
+				path: join(dir, "WORKFLOW.md"),
+				runtime: { extension: { source: "./extension.ts" } },
+			},
+		});
+
+		expect(loaded.extension.id).toBe("public-sdk-test");
+		expect(await loaded.runtime.discover()).toEqual([
+			{ id: "work:from-sdk", version: "v1" },
+		]);
+	});
+
 	test("loads a local extension module from WORKFLOW.md config", async () => {
 		const dir = await makeTempDir();
 		const extensionPath = join(dir, "extension.ts");


### PR DESCRIPTION
## Summary
- load workflow extensions through jiti instead of native dynamic import
- provide bundled virtual modules for plot-ai/sdk and @plot/sdk so compiled Plot binaries can load external TS extensions
- add a regression test for an extension importing definePlotExtension from plot-ai/sdk

## Why
A real external extension with \Version: ImageMagick 7.1.1-47 Q16-HDRI aarch64 22763 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenMP 
Delegates (built-in): bzlib fontconfig freetype gslib heic jng jp2 jpeg jxl lcms lqr ltdl lzma openexr png ps raw tiff webp xml zlib zstd
Compiler: clang (16.0.0)
Usage: import [options ...] [ file ]

Image Settings:
  -adjoin              join images into a single multi-image file
  -border              include window border in the output image
  -channel type        apply option to select image channels
  -colorspace type     alternate image colorspace
  -comment string      annotate image with comment
  -compress type       type of pixel compression when writing the image
  -define format:option
                       define one or more image format options
  -density geometry    horizontal and vertical density of the image
  -depth value         image depth
  -descend             obtain image by descending window hierarchy
  -display server      X server to contact
  -dispose method      layer disposal method
  -dither method       apply error diffusion to image
  -delay value         display the next image after pausing
  -encipher filename   convert plain pixels to cipher pixels
  -endian type         endianness (MSB or LSB) of the image
  -encoding type       text encoding type
  -filter type         use this filter when resizing an image
  -format "string"     output formatted image characteristics
  -frame               include window manager frame
  -gravity direction   which direction to gravitate towards
  -identify            identify the format and characteristics of the image
  -interlace type      None, Line, Plane, or Partition
  -interpolate method  pixel color interpolation method
  -label string        assign a label to an image
  -limit type value    Area, Disk, Map, or Memory resource limit
  -monitor             monitor progress
  -page geometry       size and location of an image canvas
  -pause seconds       seconds delay between snapshots
  -pointsize value     font point size
  -quality value       JPEG/MIFF/PNG compression level
  -quiet               suppress all warning messages
  -regard-warnings     pay attention to warning messages
  -repage geometry     size and location of an image canvas
  -respect-parentheses settings remain in effect until parenthesis boundary
  -sampling-factor geometry
                       horizontal and vertical sampling factor
  -scene value         image scene number
  -screen              select image from root window
  -seed value          seed a new sequence of pseudo-random numbers
  -set property value  set an image property
  -silent              operate silently, i.e. don't ring any bells 
  -snaps value         number of screen snapshots
  -support factor      resize support: > 1.0 is blurry, < 1.0 is sharp
  -synchronize         synchronize image to storage device
  -taint               declare the image as modified
  -transparent-color color
                       transparent color
  -treedepth value     color tree depth
  -verbose             print detailed information about the image
  -virtual-pixel method
                       Constant, Edge, Mirror, or Tile
  -window id           select window with this id or name
                       root selects whole screen

Image Operators:
  -annotate geometry text
                       annotate the image with text
  -colors value        preferred number of colors in the image
  -crop geometry       preferred size and location of the cropped image
  -encipher filename   convert plain pixels to cipher pixels
  -extent geometry     set the image size
  -geometry geometry   preferred size or location of the image
  -help                print program options
  -monochrome          transform image to black and white
  -negate              replace every pixel with its complementary color 
  -quantize colorspace reduce colors in this colorspace
  -resize geometry     resize the image
  -rotate degrees      apply Paeth rotation to the image
  -strip               strip image of all profiles and comments
  -thumbnail geometry  create a thumbnail of the image
  -transparent color   make this color transparent within the image
  -trim                trim image edges
  -type type           image type

Miscellaneous Options:
  -debug events        display copious debugging information
  -help                print program options
  -list type           print a list of supported option arguments
  -log format          format of debugging information
  -version             print version information

By default, 'file' is written in the MIFF image format.  To
specify a particular image format, precede the filename with an image
format name and a colon (i.e. ps:image) or specify the image type as
the filename suffix (i.e. image.ps).  Specify 'file' as '-' for
standard input or output. failed under the published/bunx CLI because the compiled binary's native dynamic import could not resolve the public SDK package from the extension file.

This follows pi-mono's pattern: extension loading uses jiti with bundled virtual modules for public package APIs.

## Verification
- bun run check
- bun run release:local --version 0.1.2-test.0 --skip-check --out /tmp/plot-sdk-resolution-test --force --skip-bun-install
- /tmp/plot-sdk-resolution-test/npm-install/plot run --workflow <temp workflow importing plot-ai/sdk> --log-level error