### PR TITLE
refactor(session): expose only public SDK virtual module

### DIFF
--- a/packages/session/src/extension-source.ts
+++ b/packages/session/src/extension-source.ts
@@ -259,7 +259,6 @@ export const makePlotExtensionSourceBundle = (options: {
 };
 const extensionVirtualModules: Record<string, unknown> = {
 	"plot-ai/sdk": plotSdk,
-	"@plot/sdk": plotSdk,
 };
 
 const importExtensionModule = async (source: string): Promise<unknown> => {


### PR DESCRIPTION
## Summary
- remove the private @plot/sdk alias from extension loader virtual modules
- keep only the documented public plot-ai/sdk import for extension authors

## Verification
- bun run --cwd packages/session test
- bun run typecheck