### PR TITLE
fix(tui): keep fleet selection visible

### DIFF
--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -142,6 +142,7 @@ export class PlotDashboard implements Component {
 								model,
 								selectedIndex: this.selectedIndex,
 								width,
+								maxRows: Math.max(1, (this.actions.height?.() ?? 24) - 1),
 								...this.fleetFooter(),
 							});
 		return ["", ...renderLines(lines, width, style.row.selected)];

--- a/packages/tui/src/fleet-view.ts
+++ b/packages/tui/src/fleet-view.ts
@@ -64,6 +64,32 @@ const activityGlyph = (tone: "ok" | "bad" | "info") =>
 			? style.bad("✗")
 			: style.muted("·");
 
+const clampWorkViewport = (
+	workLines: readonly DashboardLine[],
+	selectedIndex: number,
+	availableRows: number,
+): readonly DashboardLine[] => {
+	if (workLines.length <= availableRows) return workLines;
+	const selectedStart = Math.max(0, selectedIndex * 3);
+	const selectedEnd = Math.min(workLines.length - 1, selectedStart + 2);
+	const maxOffset = Math.max(0, workLines.length - availableRows);
+	const preferredOffset =
+		availableRows >= 3
+			? Math.max(0, selectedEnd - availableRows + 1)
+			: selectedStart;
+	const offset = Math.min(maxOffset, preferredOffset);
+	const visible = workLines.slice(offset, offset + availableRows);
+	if (offset === 0)
+		return [...visible.slice(0, -1), item(style.muted("    … more below"))];
+	if (offset >= maxOffset)
+		return [item(style.muted("    … more above")), ...visible.slice(1)];
+	return [
+		item(style.muted("    … more above")),
+		...visible.slice(1, -1),
+		item(style.muted("    … more below")),
+	];
+};
+
 export const fleetViewLines = (input: {
 	readonly header: readonly DashboardLine[];
 	readonly model: DashboardModel;
@@ -71,6 +97,7 @@ export const fleetViewLines = (input: {
 	readonly width: number;
 	readonly footerText: string;
 	readonly footerStyle?: (value: string) => string;
+	readonly maxRows?: number;
 	readonly nowMs?: number;
 }): readonly DashboardLine[] => {
 	const { model } = input;
@@ -101,21 +128,39 @@ export const fleetViewLines = (input: {
 					),
 					...scheduled.map(scheduledRowLine),
 				];
+	const maxActivityRows = model.work.length === 0 ? 8 : 4;
 	const activityLines =
 		model.activity.length === 0
 			? [item("  nothing yet", style.muted)]
 			: model.activity
-					.slice(0, 8)
+					.slice(0, maxActivityRows)
 					.map((entry) =>
 						item(
 							`  ${cell(entry.ago, 12, style.dim)} ${activityGlyph(entry.tone)} ${entry.text}`,
 						),
 					);
+	const chromeRows =
+		input.header.length +
+		attention.length +
+		1 +
+		1 +
+		1 +
+		activityLines.length +
+		1;
+	const availableWorkRows =
+		input.maxRows === undefined
+			? workLines.length
+			: Math.max(1, input.maxRows - chromeRows);
+	const visibleWorkLines = clampWorkViewport(
+		workLines,
+		input.selectedIndex,
+		availableWorkRows,
+	);
 	return [
 		...input.header,
 		...attention,
 		section(workTitle),
-		...workLines,
+		...visibleWorkLines,
 		blank(),
 		section("Activity"),
 		...activityLines,

--- a/packages/tui/src/fleet-view.ts
+++ b/packages/tui/src/fleet-view.ts
@@ -71,13 +71,14 @@ const clampWorkViewport = (
 ): readonly DashboardLine[] => {
 	if (workLines.length <= availableRows) return workLines;
 	const selectedStart = Math.max(0, selectedIndex * 3);
+	if (availableRows <= 3)
+		return workLines.slice(selectedStart, selectedStart + availableRows);
 	const selectedEnd = Math.min(workLines.length - 1, selectedStart + 2);
 	const maxOffset = Math.max(0, workLines.length - availableRows);
-	const preferredOffset =
-		availableRows >= 3
-			? Math.max(0, selectedEnd - availableRows + 1)
-			: selectedStart;
-	const offset = Math.min(maxOffset, preferredOffset);
+	const offset = Math.min(
+		maxOffset,
+		Math.max(0, selectedEnd - availableRows + 1),
+	);
 	const visible = workLines.slice(offset, offset + availableRows);
 	if (offset === 0)
 		return [...visible.slice(0, -1), item(style.muted("    … more below"))];

--- a/packages/tui/src/plot-tui.ts
+++ b/packages/tui/src/plot-tui.ts
@@ -41,42 +41,9 @@ export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 	>();
 	const terminal = new ProcessTerminal();
 	const tui = new TUI(terminal);
-	let lastRenderFingerprint = "";
-	let lastRenderAtMs = 0;
-	let pendingRender: ReturnType<typeof setTimeout> | undefined;
-	const renderFingerprint = () =>
-		JSON.stringify({
-			status: projection.status,
-			frontier: projection.frontier,
-			running: [...projection.running.values()].map((work) => [
-				work.workKey,
-				work.stage,
-				work.lastEventSeq,
-				work.check,
-				work.tokens?.total,
-			]),
-			pulse: projection.pulse,
-			activity: projection.activity[0]?.atMs,
-			completed: projection.completed.length,
-			diagnostics: projection.diagnostics,
-			scheduledWakes: projection.scheduledWakes,
-			clockSecond: Math.floor(Date.now() / 1000),
-		});
 	const render = () => {
 		dashboard.setProjection(projection);
-		const fingerprint = renderFingerprint();
-		if (fingerprint === lastRenderFingerprint) return;
-		const now = Date.now();
-		const elapsed = now - lastRenderAtMs;
-		const requestRender = () => {
-			pendingRender = undefined;
-			lastRenderFingerprint = renderFingerprint();
-			lastRenderAtMs = Date.now();
-			tui.requestRender();
-		};
-		if (elapsed >= 50) requestRender();
-		else if (pendingRender === undefined)
-			pendingRender = setTimeout(requestRender, 50 - elapsed);
+		tui.requestRender();
 	};
 	const setProjection = (next: DashboardProjection) => {
 		projection = next;
@@ -208,7 +175,6 @@ export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 		refresh();
 		await stopped;
 	} finally {
-		if (pendingRender !== undefined) clearTimeout(pendingRender);
 		tui.stop();
 		await host.session.shutdown();
 		await host.shutdown();

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -225,10 +225,15 @@ describe("PlotDashboard", () => {
 				] as const;
 			}),
 		);
-		const dashboard = new PlotDashboard(
-			{ ...emptyProjection("default", "workflow"), status: "running", running },
-			{ ...actions, height: () => 18 },
-		);
+		const projection = {
+			...emptyProjection("default", "workflow"),
+			status: "running" as const,
+			running,
+		};
+		const dashboard = new PlotDashboard(projection, {
+			...actions,
+			height: () => 18,
+		});
 
 		for (let i = 0; i < 7; i++) dashboard.handleInput("j");
 		const rendered = stripAnsi(dashboard.render(100).join("\n"));
@@ -237,6 +242,16 @@ describe("PlotDashboard", () => {
 		expect(rendered).toContain("… more above");
 		expect(rendered).not.toContain("#1 Item 1");
 		expect(rendered.split("\n").length).toBeLessThanOrEqual(18);
+
+		const tinyDashboard = new PlotDashboard(projection, {
+			...actions,
+			height: () => 14,
+		});
+		for (let i = 0; i < 4; i++) tinyDashboard.handleInput("j");
+		const tinyRendered = stripAnsi(tinyDashboard.render(100).join("\n"));
+
+		expect(tinyRendered).toContain("› ● #5 Item 5");
+		expect(tinyRendered.split("\n").length).toBeLessThanOrEqual(14);
 	});
 
 	test("promotes blocked work into the attention strip", () => {

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -209,6 +209,36 @@ describe("PlotDashboard", () => {
 		expect(rendered).not.toContain("DEBUG EVENTS");
 	});
 
+	test("keeps selected fleet work visible in small terminals", () => {
+		const running = new Map(
+			Array.from({ length: 8 }, (_, index) => {
+				const id = index + 1;
+				return [
+					`source:item:${id}`,
+					runningWork({
+						workKey: `source:item:${id}`,
+						primary: `#${id}`,
+						title: `Item ${id}`,
+						activity: `Working item ${id}`,
+						lastMeaningful: `Working item ${id}`,
+					}),
+				] as const;
+			}),
+		);
+		const dashboard = new PlotDashboard(
+			{ ...emptyProjection("default", "workflow"), status: "running", running },
+			{ ...actions, height: () => 18 },
+		);
+
+		for (let i = 0; i < 7; i++) dashboard.handleInput("j");
+		const rendered = stripAnsi(dashboard.render(100).join("\n"));
+
+		expect(rendered).toContain("› ● #8 Item 8");
+		expect(rendered).toContain("… more above");
+		expect(rendered).not.toContain("#1 Item 1");
+		expect(rendered.split("\n").length).toBeLessThanOrEqual(18);
+	});
+
 	test("promotes blocked work into the attention strip", () => {
 		const running = new Map([
 			[


### PR DESCRIPTION
## Summary
- align Plot TUI render scheduling with pi-tui requestRender coalescing instead of a second 50ms throttle
- clamp the fleet work list to the terminal height so busy dashboards do not overflow
- keep the selected running work visible while moving through a large fleet and show overflow hints

## Verification
- bun run check