### PR TITLE
fix(tui): prevent projection updates from reviving the render clock after shutdown

### DIFF
--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -65,6 +65,7 @@ export class PlotDashboard implements Component {
 	private confirmQuit = false;
 	private liveRenderTimer: ReturnType<typeof setInterval> | undefined;
 	private liveRenderIntervalMs: number | undefined;
+	private liveUpdatesActive = false;
 	private readonly actions: DashboardActions;
 
 	constructor(projection: DashboardProjection, actions: DashboardActions) {
@@ -78,10 +79,12 @@ export class PlotDashboard implements Component {
 	}
 
 	startLiveUpdates(): void {
+		this.liveUpdatesActive = true;
 		this.syncLiveRenderTimer();
 	}
 
 	stopLiveUpdates(): void {
+		this.liveUpdatesActive = false;
 		if (this.liveRenderTimer !== undefined) clearInterval(this.liveRenderTimer);
 		this.liveRenderTimer = undefined;
 		this.liveRenderIntervalMs = undefined;
@@ -194,14 +197,22 @@ export class PlotDashboard implements Component {
 	}
 
 	private syncLiveRenderTimer(): void {
+		// Projection updates can arrive from late async callbacks after the
+		// TUI begins shutting down; the render clock may only exist between
+		// startLiveUpdates and stopLiveUpdates.
+		if (!this.liveUpdatesActive) return;
 		const next = this.desiredLiveRenderInterval();
 		if (next === this.liveRenderIntervalMs) return;
 		if (this.liveRenderTimer !== undefined) clearInterval(this.liveRenderTimer);
 		this.liveRenderIntervalMs = next;
-		this.liveRenderTimer =
-			next === undefined
-				? undefined
-				: setInterval(() => this.actions.requestRender?.(), next);
+		if (next === undefined) {
+			this.liveRenderTimer = undefined;
+			return;
+		}
+		const timer = setInterval(() => this.actions.requestRender?.(), next);
+		// A stray render clock must never hold the process open.
+		timer.unref?.();
+		this.liveRenderTimer = timer;
 	}
 
 	private viewportRows(): number {

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -13,6 +13,13 @@ const fixture = (name: string) =>
 		"utf8",
 	);
 
+const waitFor = async (condition: () => boolean, timeoutMs = 2_000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (!condition() && Date.now() < deadline)
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	return condition();
+};
+
 const escape = String.fromCharCode(27);
 const stripAnsi = (text: string) =>
 	text.replace(new RegExp(`${escape}\\[[0-9;]*m`, "g"), "");
@@ -396,5 +403,66 @@ describe("PlotDashboard", () => {
 		expect(toggled).toBe(true);
 		expect(rendered).toContain("DEBUG EVENTS");
 		expect(rendered).toContain("#2 agent_session_event");
+	});
+
+	describe("live render clock", () => {
+		const runningProjection = () => ({
+			...emptyProjection("default", "workflow"),
+			running: new Map([["work-1", runningWork({ workKey: "work-1" })]]),
+		});
+
+		test("running work drives render requests between start and stop", async () => {
+			let renders = 0;
+			const dashboard = new PlotDashboard(runningProjection(), {
+				...actions,
+				requestRender: () => {
+					renders += 1;
+				},
+			});
+			dashboard.startLiveUpdates();
+			try {
+				expect(await waitFor(() => renders > 0)).toBe(true);
+			} finally {
+				dashboard.stopLiveUpdates();
+			}
+		});
+
+		test("projection updates cannot restart the clock after stopLiveUpdates", async () => {
+			let renders = 0;
+			const dashboard = new PlotDashboard(runningProjection(), {
+				...actions,
+				requestRender: () => {
+					renders += 1;
+				},
+			});
+			dashboard.startLiveUpdates();
+			await waitFor(() => renders > 0);
+			dashboard.stopLiveUpdates();
+			// A late async projection update arriving mid-shutdown.
+			dashboard.setProjection(runningProjection());
+			const after = renders;
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			expect(renders).toBe(after);
+		});
+
+		test("an idle projection retunes the clock off while live", async () => {
+			let renders = 0;
+			const dashboard = new PlotDashboard(runningProjection(), {
+				...actions,
+				requestRender: () => {
+					renders += 1;
+				},
+			});
+			dashboard.startLiveUpdates();
+			try {
+				await waitFor(() => renders > 0);
+				dashboard.setProjection(emptyProjection("default", "workflow"));
+				const after = renders;
+				await new Promise((resolve) => setTimeout(resolve, 300));
+				expect(renders).toBe(after);
+			} finally {
+				dashboard.stopLiveUpdates();
+			}
+		});
 	});
 });


### PR DESCRIPTION
Fixes the P1 the Plot reviewer raised against #112 (recorded in its anchor comment): `setProjection` always re-synced the live render timer, so a late protocol event, refresh, or failure callback arriving after `stopLiveUpdates` could recreate the interval and keep requesting renders on a stopped TUI.

- Gate the render clock on an explicit live-updates flag: it can only exist between `startLiveUpdates` and `stopLiveUpdates`; late projection updates while inactive are state-only.
- `unref` the interval as a second guard so a stray clock can never hold the process open.
- Add the behavior tests the reviewer asked for: running work drives render requests while live; a projection update after stop cannot revive the clock; an idle projection retunes the clock off.
