### PR TITLE
feat(tui): show recent completions

### DIFF
--- a/examples/pr-review/WORKFLOW.md
+++ b/examples/pr-review/WORKFLOW.md
@@ -90,7 +90,7 @@ All review state lives in one issue comment you maintain on the PR (the "anchor"
 <!-- plot-review:v1 status=<phase> head=<full-head-sha> tier=<trivial|lite|full> -->
 ```
 
-The marker is the commit point: update its `status` only when a phase is finished. Keys and values contain no spaces; `head` is the full 40-char SHA. The findings you record in the anchor are your only memory between ticks — write them so a stranger (the next tick's you) can act on them without re-deriving anything.
+The marker is the commit point: update its `status` only when a phase is finished. Keys and values contain no spaces; `head` is the full 40-char SHA. The anchor is Plot's checkpoint, not a second polished code review. Keep it compact, structured, and easy for the next tick to parse. The findings you record there are your only memory between ticks — write enough evidence for a stranger to verify or drop each record without re-deriving everything.
 
 ## prepare: risk tier and phase plan
 
@@ -116,8 +116,8 @@ Wear only the current hat. Each hat states what NOT to flag because that is wher
 - `protocol` — machine-protocol compatibility: JSONL framing, stdout/stderr split, schema changes, replay/order semantics, malformed-input behavior. Verify both producer and consumer sides.
 - `tests` — whether meaningful success/failure/cancellation/boundary paths are proven. Do NOT ask for tests that add no confidence; missing tests matter most for new public API, protocol boundaries, lifecycle changes, and bug fixes without regression tests.
 - `docs_agents` — instruction freshness: do AGENTS.md/WORKFLOW.md/commands need updating because this PR changed architecture, package manager, test framework, CI, or workflows? Materiality tiers: build/test/structure changes are high; dependency bumps medium; bug fixes low. Also flag instruction-file rot: generic filler, stale commands.
-- `synthesize` — the judge pass, and the hat that most determines output quality. Read every finding in the anchor. Deduplicate (keep one copy in the best section). Re-verify anything surprising or high-severity by reading the code again — prove it or drop it. Drop findings contradicted by tests or surrounding code. Demote findings on files this PR does not change to body-level notes. Then write the final findings list into the anchor.
-- `post` — publish exactly one GitHub review for this head, then set the marker to `status=done`.
+- `synthesize` — the judge pass, and the hat that most determines output quality. Read every finding record in the anchor. Deduplicate (keep one record with the clearest consequence). Re-verify anything surprising or high-severity by reading the code again — prove it or drop it. Drop findings contradicted by tests or surrounding code. Demote findings on files this PR does not change to body-level notes. Then write the final compact finding records into the anchor.
+- `post` — turn the compact anchor records into exactly one GitHub review for this head, then set the marker to `status=done`.
 
 ## Judgment rules
 
@@ -184,12 +184,12 @@ Transient GitHub errors are not blockers; fall back before reporting:
 
 ## Anchor template
 
-Use this exact structure for the anchor comment and keep it updated in place:
+Use this exact structure for the anchor comment and keep it updated in place. The anchor is durable machine/human state for Plot, so keep findings as compact records. Do not copy the polished GitHub review body back into the anchor.
 
 ```md
 <!-- plot-review:v1 status=<phase> head=<full-sha> tier=<tier> -->
 
-## Plot Review — in progress
+## Plot Review State
 
 **Head:** `<full-sha>` · **Tier:** `<tier>` · **Phase:** `<current phase>`
 
@@ -201,25 +201,24 @@ Use this exact structure for the anchor comment and keep it updated in place:
 - [ ] synthesize
 - [ ] post
 
-### Findings
+### Finding records
 
-#### ![P1](https://img.shields.io/badge/P1-orange?style=flat) <Finding title: the consequence, not the category> — `path/to/file.ts:42`
-
-**Impact:** <What breaks, when, for whom — consequence first, e.g. "Quit while a run is streaming and the render clock keeps firing on a dead screen.">
-**Fix:** <The concrete change, named, e.g. "Gate `syncLiveRenderTimer` on a flag owned by `startLiveUpdates`/`stopLiveUpdates`.">
-
-<details><summary>Evidence</summary>
-
-<The code that proves it — quote the conflicting lines with `path:line` references rather than describing them.>
-
-</details>
+- **P1** `path/to/file.ts:42` — <Finding title: the consequence, not the category>
+  - Status: <candidate | verified | dropped | posted>
+  - Impact: <one sentence consequence first>
+  - Fix: <one concrete change>
+  - Evidence: <short code reference or command result; use `<details>` only if the evidence needs multiple lines>
 
 ### Carried from previous head
 
-<Only on re-review: prior findings pending verification against the new head.>
+<Only on re-review: prior findings pending verification against the new head, using the same compact record shape.>
+
+### Posted review
+
+<Only after post: link to the GitHub review.>
 ```
 
-When the review completes, the heading becomes `## Plot Review — <DISPOSITION>` and a final line links to the posted review.
+When the review completes, keep the heading `## Plot Review State`, set the marker and phase to `done`, mark posted findings as `Status: posted`, and add the posted review link. The GitHub review is the author-facing report; the anchor remains the checkpoint.
 
 ## Review body template
 
@@ -233,7 +232,7 @@ When the review completes, the heading becomes `## Plot Review — <DISPOSITION>
 
 ### Findings
 
-<Same per-finding block format as the anchor. In-diff findings appear here briefly AND as inline comments; out-of-diff findings appear here only.>
+<Expand the compact anchor records into author-facing prose. In-diff findings appear here briefly AND as inline comments; out-of-diff findings appear here only. Use the badge + title, impact, fix, and evidence shape from the judgment rules, but avoid duplicating long evidence in both the body and inline comments.>
 
 ### Re-review
 

--- a/examples/pr-review/WORKFLOW.md
+++ b/examples/pr-review/WORKFLOW.md
@@ -133,12 +133,14 @@ Out-of-scope discoveries: a serious pre-existing bug in code this PR does not ch
 
 ## Voice
 
-Everything you publish — anchor, review body, inline comments — is read by the PR author, a busy engineer. Write like a sharp colleague at a whiteboard, not a bot filing a report.
+Everything you publish — review body and inline comments — is read by the PR author, a busy engineer. Write like a clear teacher-reviewer pairing with the author, not a bot filing a report. The anchor stays compact state; the review is where you teach.
 
 - Talk to the author, second person, about their code. "You clear the timer in `stopLiveUpdates`, but a late `setProjection` recreates it." Never "It was observed that the timer may be recreated."
-- Lead with the consequence, then teach the mechanism. The reader should know why they care by the end of the first sentence.
-- Short sentences. One idea each. Momentum over completeness.
-- Show, don't narrate: quote the two lines that conflict instead of describing them. Every identifier, path, and command in backticks. Use a fenced snippet when the evidence is the code.
+- Start with the user-visible consequence. Then explain the mechanism.
+- Teach with the smallest concrete example that proves the point.
+- Prefer short paragraphs and bullets over dense report blocks.
+- Use code quotes as the UX. Show the conflicting expression or branch, then explain it.
+- Name the mental-model mismatch. Example: "The cursor says selected work, but the browser opens completed work."
 - Kill bot-speak on sight: "As part of this review", "It is worth noting that", "Please consider", "This finding pertains to", "may potentially". If a sentence survives without a word, delete the word.
 - No hedging when you have evidence: "this breaks shutdown", not "this could potentially affect shutdown behavior". When you genuinely could not prove something, say exactly that and what you checked.
 - Praise only when specific and earned — name the exact decision that is good and why it holds. Generic compliments are noise.
@@ -148,7 +150,7 @@ Calibrate against this pair:
 
 Bad: "**Impact:** This issue may potentially lead to unexpected behavior in certain scenarios where the component lifecycle is not properly managed during shutdown."
 
-Good: "**Impact:** Quit the TUI while a run is streaming and the render clock keeps firing on a dead screen. The process can't exit."
+Good: "Quit the TUI while a run is streaming and the render clock keeps firing on a dead screen. The process can't exit."
 
 ## post: publishing the review
 
@@ -232,7 +234,19 @@ When the review completes, keep the heading `## Plot Review State`, set the mark
 
 ### Findings
 
-<Expand the compact anchor records into author-facing prose. In-diff findings appear here briefly AND as inline comments; out-of-diff findings appear here only. Use the badge + title, impact, fix, and evidence shape from the judgment rules, but avoid duplicating long evidence in both the body and inline comments.>
+<Expand compact anchor records into author-facing prose. Use this shape:
+
+#### ![P1](https://img.shields.io/badge/P1-orange?style=flat) <Consequence-first title>
+
+<One short paragraph: what breaks, when, and why the author should care.>
+
+<Smallest code quote or expression that proves it. Use a fenced snippet in the real review when the evidence is code.>
+
+<One short paragraph explaining the mechanism.>
+
+**Fix:** <Specific change, ideally as a small branch, table, or bullet list.>
+
+In-diff findings also get inline comments. In the review body, keep evidence short and link the idea together; put line-local detail in the inline comment. Out-of-diff findings appear in the body only.>
 
 ### Re-review
 
@@ -243,7 +257,21 @@ When the review completes, keep the heading `## Plot Review State`, set the mark
 _Review state: <link to anchor comment>_
 ```
 
-Inline comment bodies use the same shape, compact: badge + title, impact line, fix line, evidence in `<details>`.
+Inline comment bodies are compact teaching notes:
+
+````md
+![P1](https://img.shields.io/badge/P1-orange?style=flat) **<Consequence-first title>**
+
+<What breaks in one or two sentences.>
+
+```ts
+<the exact line or expression>
+```
+
+**Fix:** <specific change.>
+````
+
+Use `<details>` only when the proof needs multiple snippets.
 
 ## Final response
 

--- a/packages/tui/src/dashboard-model.ts
+++ b/packages/tui/src/dashboard-model.ts
@@ -51,6 +51,15 @@ export interface ScheduledRowModel {
 	readonly attempt?: number;
 }
 
+export interface CompletedRowModel {
+	readonly label: string;
+	readonly status: string;
+	readonly message: string;
+	readonly ago: string;
+	readonly tone: ActivityTone;
+	readonly url?: string;
+}
+
 export interface ActivityRowModel {
 	readonly ago: string;
 	readonly tone: ActivityTone;
@@ -62,6 +71,7 @@ export interface DashboardModel {
 	readonly attention: readonly AttentionItemModel[];
 	readonly work: readonly WorkRowModel[];
 	readonly scheduled: readonly ScheduledRowModel[];
+	readonly completed: readonly CompletedRowModel[];
 	readonly activity: readonly ActivityRowModel[];
 }
 
@@ -238,6 +248,14 @@ export const dashboardModelFrom = (
 				...(wake.attempt === undefined ? {} : { attempt: wake.attempt }),
 			};
 		}),
+		completed: projection.completed.slice(0, 5).map((entry) => ({
+			label: entry.label,
+			status: entry.status,
+			message: entry.message,
+			ago: formatAgo(nowMs - entry.atMs),
+			tone: entry.status === "succeeded" ? "ok" : "bad",
+			...(entry.url === undefined ? {} : { url: entry.url }),
+		})),
 		activity: projection.activity.slice(0, 20).map((entry) => ({
 			ago: formatAgo(nowMs - entry.atMs),
 			tone: entry.tone,

--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -182,7 +182,9 @@ export class PlotDashboard implements Component {
 
 	private openSelectedUrl(): void {
 		const model = dashboardModelFrom(this.projection);
-		const url = model.work[this.selectedIndex]?.work.url;
+		const url =
+			model.work[this.selectedIndex]?.work.url ??
+			(this.mode === "fleet" ? model.completed[0]?.url : undefined);
 		if (url !== undefined) this.actions.openUrl?.(url);
 	}
 

--- a/packages/tui/src/fleet-view.ts
+++ b/packages/tui/src/fleet-view.ts
@@ -1,7 +1,8 @@
 import type {
+	CompletedRowModel,
 	DashboardModel,
-	WorkRowModel,
 	ScheduledRowModel,
+	WorkRowModel,
 } from "./dashboard-model.js";
 import {
 	blank,
@@ -48,6 +49,17 @@ const scheduledRowLine = (wake: ScheduledRowModel): DashboardLine => {
 		wake.attempt === undefined ? "" : ` · attempt ${wake.attempt}`;
 	return item(
 		`    ${style.warn("↻")} ${style.muted(`${retry} in ${wake.inSeconds}s${attempt}${wake.reason === undefined ? "" : ` · ${wake.reason}`}`)}`,
+	);
+};
+
+const completionRowLine = (row: CompletedRowModel): DashboardLine => {
+	const glyph = row.tone === "ok" ? style.ok("✓") : style.bad("✗");
+	const message =
+		row.message === "completed" || row.message === row.status
+			? ""
+			: ` · ${row.message}`;
+	return item(
+		`  ${cell(row.ago, 12, style.dim)} ${glyph} ${style.text(row.label)} ${style.muted(`${row.status}${message}`)}`,
 	);
 };
 
@@ -129,7 +141,13 @@ export const fleetViewLines = (input: {
 					),
 					...scheduled.map(scheduledRowLine),
 				];
-	const maxActivityRows = model.work.length === 0 ? 8 : 4;
+	const completionLines = model.completed.map(completionRowLine);
+	const completionBlock =
+		completionLines.length === 0
+			? []
+			: [blank(), section("Completed"), ...completionLines];
+	const maxActivityRows =
+		model.work.length === 0 && completionLines.length === 0 ? 8 : 4;
 	const activityLines =
 		model.activity.length === 0
 			? [item("  nothing yet", style.muted)]
@@ -145,6 +163,7 @@ export const fleetViewLines = (input: {
 		attention.length +
 		1 +
 		1 +
+		completionBlock.length +
 		1 +
 		activityLines.length +
 		1;
@@ -162,6 +181,7 @@ export const fleetViewLines = (input: {
 		...attention,
 		section(workTitle),
 		...visibleWorkLines,
+		...completionBlock,
 		blank(),
 		section("Activity"),
 		...activityLines,

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -382,6 +382,40 @@ describe("PlotDashboard", () => {
 		expect(opened).toEqual(["https://example.com/pr/42"]);
 	});
 
+	test("shows recent completions and opens the latest completed url", () =>
+		withFixedNow(() => {
+			const opened: string[] = [];
+			const dashboard = new PlotDashboard(
+				{
+					...emptyProjection("default", "workflow"),
+					completed: [
+						{
+							workKey: "source:item:42",
+							label: "#42 Item 42",
+							status: "succeeded",
+							message: "review posted",
+							atMs: fixedNowMs - 3_000,
+							url: "https://example.com/pr/42",
+						},
+					],
+				},
+				{
+					...actions,
+					openUrl: (url) => {
+						opened.push(url);
+					},
+				},
+			);
+
+			const rendered = stripAnsi(dashboard.render(120).join("\n"));
+			expect(rendered).toContain("Completed");
+			expect(rendered).toContain("3s ago");
+			expect(rendered).toContain("#42 Item 42 succeeded · review posted");
+
+			dashboard.handleInput("o");
+			expect(opened).toEqual(["https://example.com/pr/42"]);
+		}));
+
 	test("debug mode exposes retained raw events", () => {
 		let toggled = false;
 		const dashboard = new PlotDashboard(


### PR DESCRIPTION
## Summary
- show recent completed work in the TUI fleet view
- allow `o` to open the latest completed work URL when idle
- add dashboard coverage for completions

## Verification
- bun run check
