### PR TITLE
fix(tui): keep open action on selected work

### DIFF
--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -182,9 +182,11 @@ export class PlotDashboard implements Component {
 
 	private openSelectedUrl(): void {
 		const model = dashboardModelFrom(this.projection);
+		const selected = model.work[this.selectedIndex];
 		const url =
-			model.work[this.selectedIndex]?.work.url ??
-			(this.mode === "fleet" ? model.completed[0]?.url : undefined);
+			selected === undefined && this.mode === "fleet"
+				? model.completed[0]?.url
+				: selected?.work.url;
 		if (url !== undefined) this.actions.openUrl?.(url);
 	}
 

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -416,6 +416,44 @@ describe("PlotDashboard", () => {
 			expect(opened).toEqual(["https://example.com/pr/42"]);
 		}));
 
+	test("does not open a completed url while work without a url is selected", () => {
+		const opened: string[] = [];
+		const dashboard = new PlotDashboard(
+			{
+				...emptyProjection("default", "workflow"),
+				running: new Map([
+					[
+						"source:item:41",
+						runningWork({
+							workKey: "source:item:41",
+							primary: "#41",
+							title: "Item 41",
+						}),
+					],
+				]),
+				completed: [
+					{
+						workKey: "source:item:42",
+						label: "#42 Item 42",
+						status: "succeeded",
+						message: "review posted",
+						atMs: fixedNowMs - 3_000,
+						url: "https://example.com/pr/42",
+					},
+				],
+			},
+			{
+				...actions,
+				openUrl: (url) => {
+					opened.push(url);
+				},
+			},
+		);
+
+		dashboard.handleInput("o");
+		expect(opened).toEqual([]);
+	});
+
 	test("debug mode exposes retained raw events", () => {
 		let toggled = false;
 		const dashboard = new PlotDashboard(


### PR DESCRIPTION
## Summary
- keep `o` scoped to the selected running work when a row exists
- only fall back to the latest completed URL when no work row is selected
- add a regression test for selected work without a URL

## Verification
- bun run check
