### PR TITLE
fix(tui): show current agent activity

### DIFF
--- a/packages/tui/src/dashboard-model.ts
+++ b/packages/tui/src/dashboard-model.ts
@@ -110,6 +110,25 @@ const isStale = (work: RunningWorkProjection, nowMs: number) =>
 
 const tokenTotal = (work: RunningWorkProjection) => work.tokens?.total ?? 0;
 
+const isRawEventChurn = (activity: string) =>
+	/\b(message_(update|delta)|reasoning_(update|delta)|tool_execution_update)\b/.test(
+		activity,
+	);
+
+const displayActivity = (work: RunningWorkProjection) => {
+	const activity = work.activity.trim();
+	if (activity.length === 0 || isRawEventChurn(activity))
+		return work.lastMeaningful;
+	if (
+		activity === "Thinking" &&
+		work.lastMeaningful !== "started" &&
+		work.lastMeaningful !== "waiting" &&
+		work.lastMeaningful !== "Thinking"
+	)
+		return work.lastMeaningful;
+	return activity;
+};
+
 const sparkChars = "▁▂▃▄▅▆▇█";
 const throughputWindowMs = 60 * 1000;
 const throughputBuckets = 8;
@@ -156,7 +175,7 @@ const workRow = (work: RunningWorkProjection, nowMs: number): WorkRowModel => ({
 			: formatDuration(nowMs - work.startedAtMs),
 	turns: `t${work.turnCount}`,
 	tokens: formatTokens(tokenTotal(work)),
-	activity: work.lastMeaningful,
+	activity: displayActivity(work),
 	lastEventAgo:
 		work.lastEventAtMs === undefined
 			? ""

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -197,6 +197,34 @@ describe("PlotDashboard", () => {
 		expect(rendered).not.toContain("message_update");
 	});
 
+	test("shows humanized streaming activity in fleet rows", () => {
+		const dashboard = new PlotDashboard(
+			{
+				...emptyProjection("default", "workflow"),
+				status: "running",
+				running: new Map([
+					[
+						"source:item:42",
+						runningWork({
+							workKey: "source:item:42",
+							primary: "#42",
+							title: "Item 42",
+							activity:
+								"agent message streaming: checking the selected-row URL behavior",
+							lastMeaningful: "started",
+						}),
+					],
+				]),
+			},
+			actions,
+		);
+
+		const rendered = stripAnsi(dashboard.render(120).join("\n"));
+
+		expect(rendered).toContain("“checking the selected-row URL behavior”");
+		expect(rendered).not.toContain("│     started");
+	});
+
 	test("renders a two-line board row per running work", () => {
 		const running = new Map([
 			[


### PR DESCRIPTION
## Summary
- show humanized current activity in fleet rows instead of always falling back to last meaningful activity
- keep raw event names like `message_update` out of the fleet
- keep `Thinking` as a fallback instead of letting it hide more useful activity

## Reference
- Matched Symphony Elixir's pattern of showing the latest humanized agent event in the status row.

## Verification
- bun run check
