### PR TITLE
fix(tui): clamp selection before opening urls

### DIFF
--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -182,11 +182,13 @@ export class PlotDashboard implements Component {
 
 	private openSelectedUrl(): void {
 		const model = dashboardModelFrom(this.projection);
-		const selected = model.work[this.selectedIndex];
-		const url =
-			selected === undefined && this.mode === "fleet"
-				? model.completed[0]?.url
-				: selected?.work.url;
+		if (model.work.length > 0) {
+			this.selectedIndex = Math.min(this.selectedIndex, model.work.length - 1);
+			const url = model.work[this.selectedIndex]?.work.url;
+			if (url !== undefined) this.actions.openUrl?.(url);
+			return;
+		}
+		const url = this.mode === "fleet" ? model.completed[0]?.url : undefined;
 		if (url !== undefined) this.actions.openUrl?.(url);
 	}
 

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -482,6 +482,46 @@ describe("PlotDashboard", () => {
 		expect(opened).toEqual([]);
 	});
 
+	test("open clamps stale selection before falling back to completions", () => {
+		const opened: string[] = [];
+		const dashboard = new PlotDashboard(
+			{
+				...emptyProjection("default", "workflow"),
+				running: new Map([
+					[
+						"source:item:41",
+						runningWork({
+							workKey: "source:item:41",
+							primary: "#41",
+							title: "Item 41",
+							url: "https://example.com/pr/41",
+						}),
+					],
+				]),
+				completed: [
+					{
+						workKey: "source:item:42",
+						label: "#42 Item 42",
+						status: "succeeded",
+						message: "review posted",
+						atMs: fixedNowMs - 3_000,
+						url: "https://example.com/pr/42",
+					},
+				],
+			},
+			{
+				...actions,
+				openUrl: (url) => {
+					opened.push(url);
+				},
+			},
+		);
+
+		dashboard.handleInput("j");
+		dashboard.handleInput("o");
+		expect(opened).toEqual(["https://example.com/pr/41"]);
+	});
+
 	test("debug mode exposes retained raw events", () => {
 		let toggled = false;
 		const dashboard = new PlotDashboard(


### PR DESCRIPTION
## Summary
- clamp stale fleet selection inside the `o` open action
- keep completed URL fallback only for empty active work
- add regression coverage for rapid down/open before render clamps selection

## Verification
- bun run check
