### PR TITLE
fix(cli): run root TUI entrypoint

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,11 +30,17 @@ const rootArgs = {
 	},
 };
 
-const runRootTui = async ({ args }: { args: ParsedArgs }) => {
-	const { runPlotTui } = await import("@plot/tui/plot-tui");
+const runRootTui = async ({
+	args,
+	rawArgs,
+}: {
+	args: ParsedArgs;
+	rawArgs: readonly string[];
+}) => {
 	const io = getCliIo();
-	const noServer = bool(args, "no-server");
-	return runPlotTui({
+	const runTui = io.runTui ?? (await import("@plot/tui/plot-tui")).runPlotTui;
+	const noServer = bool(args, "no-server") || rawArgs.includes("--no-server");
+	return runTui({
 		...baseOptions(args),
 		...(noServer ? { noServer: true } : {}),
 		...(io.createAgentSession === undefined
@@ -69,10 +75,17 @@ const rootMeta = {
 	description: "A control plane for long-running coding agents.",
 };
 
+const rootTuiCommand = defineCommand({
+	meta: rootMeta,
+	args: rootArgs,
+	run: runRootTui,
+});
+
 const rootCommand = defineCommand({
 	meta: rootMeta,
 	args: rootArgs,
 	subCommands,
+	run: runRootTui,
 });
 
 const stringOptions = new Set([
@@ -116,7 +129,7 @@ const subCommandInvocation = (args: readonly string[]) => {
 				commandName: arg as keyof typeof subCommands,
 				args: [...args.slice(0, index), ...args.slice(index + 1)],
 			};
-		return undefined;
+		return null;
 	}
 	return undefined;
 };
@@ -132,6 +145,14 @@ export const runPlotCli = async (
 	}
 	setCliIo(io);
 	const subCommand = subCommandInvocation(args);
+	if (subCommand === null) {
+		await io.writeStdout(
+			stripInternalCommands(
+				await renderUsage(rootCommand as unknown as CommandDef),
+			),
+		);
+		return;
+	}
 	if (subCommand !== undefined) {
 		await runCittyCommand(
 			subCommands[subCommand.commandName] as unknown as CommandDef,
@@ -142,11 +163,10 @@ export const runPlotCli = async (
 		);
 		return;
 	}
-	await io.writeStdout(
-		stripInternalCommands(
-			await renderUsage(rootCommand as unknown as CommandDef),
-		),
-	);
+	await runCittyCommand(rootTuiCommand as unknown as CommandDef, {
+		rawArgs: [...args],
+		showUsage: false,
+	});
 };
 
 export const makePlotCommand = (_io: PlotCliIo = processCliIo()) => ({

--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -6,6 +6,7 @@ export interface PlotCliIo {
 	readonly writeStdout: (text: string) => Promise<void> | void;
 	readonly writeStderr?: (text: string) => Promise<void> | void;
 	readonly createAgentSession?: CreateAgentSession;
+	readonly runTui?: (options: unknown) => Promise<void> | void;
 }
 
 class PlotCliIoError extends Error {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -6,7 +6,7 @@ import {
 import { writePlotFauxAgentFiles } from "@plot/session/testing/faux-agent-session";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { runPlotCli } from "../src/cli.js";
 
 const tempDirs: string[] = [];
@@ -138,6 +138,58 @@ describe("plot CLI", () => {
 		const output = stdout.join("");
 		expect(output).toContain("plot [OPTIONS]");
 		expect(output).not.toContain("_serve");
+	});
+
+	test("runs the root TUI entrypoint when no subcommand is provided", async () => {
+		const workflowPath = await makeWorkflowFile();
+		const stdout: string[] = [];
+		const calls: unknown[] = [];
+
+		await runPlotCli(
+			[
+				"--workflow",
+				workflowPath,
+				"--cwd",
+				dirname(workflowPath),
+				"--no-server",
+			],
+			{
+				stdin: chunks([]),
+				writeStdout: (line) => {
+					stdout.push(line);
+				},
+				runTui: (options) => {
+					calls.push(options);
+				},
+			},
+		);
+
+		expect(stdout).toEqual([]);
+		expect(calls).toEqual([
+			expect.objectContaining({
+				workflowPath,
+				cwd: dirname(workflowPath),
+				noServer: true,
+			}),
+		]);
+	});
+
+	test("prints usage instead of running TUI for an unknown subcommand", async () => {
+		const stdout: string[] = [];
+		const calls: unknown[] = [];
+
+		await runPlotCli(["wat"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+			runTui: (options) => {
+				calls.push(options);
+			},
+		});
+
+		expect(stdout.join("")).toContain("plot [OPTIONS]");
+		expect(calls).toEqual([]);
 	});
 
 	test("allows root options before a subcommand", async () => {

--- a/packages/control/src/dashboard-model.ts
+++ b/packages/control/src/dashboard-model.ts
@@ -25,6 +25,7 @@ export type PulseTickModel = z.infer<typeof pulseTickModelSchema>;
 export const pulseNextWakeModelSchema = z
 	.object({
 		inSeconds: nonNegativeIntegerSchema,
+		kind: z.enum(["wake", "retry"]).optional(),
 		reason: z.string().optional(),
 	})
 	.strict();
@@ -33,6 +34,7 @@ export type PulseNextWakeModel = z.infer<typeof pulseNextWakeModelSchema>;
 export const pulseModelSchema = z
 	.object({
 		tick: pulseTickModelSchema.optional(),
+		nextTick: pulseNextWakeModelSchema.optional(),
 		nextWake: pulseNextWakeModelSchema.optional(),
 		runningCount: nonNegativeIntegerSchema,
 		maxConcurrentRuns: nonNegativeIntegerSchema.optional(),
@@ -61,6 +63,7 @@ export const workRowModelSchema = z
 		age: z.string(),
 		turns: z.string(),
 		tokens: z.string(),
+		meta: z.string(),
 		activity: z.string(),
 		lastEventAgo: z.string(),
 		stale: z.boolean(),
@@ -86,6 +89,7 @@ export const completedRowModelSchema = z
 		status: z.string(),
 		message: z.string(),
 		ago: z.string(),
+		meta: z.string().optional(),
 		tone: activityToneSchema,
 		url: z.string().optional(),
 	})
@@ -202,29 +206,56 @@ const tokenThroughput = (
 	return { rate, graph };
 };
 
+const compactLabels = (labels: readonly string[] | undefined) =>
+	(labels ?? []).slice(0, 4).join(" · ");
+
+const shortRunId = (runId: string | undefined) => {
+	if (runId === undefined) return undefined;
+	if (runId.length <= 12) return runId;
+	return `${runId.slice(0, 8)}…${runId.slice(-4)}`;
+};
+
+const tokenMeta = (tokens: AgentAttemptProjection["tokens"] | undefined) => {
+	const total = tokens?.total ?? 0;
+	if (total === 0) return undefined;
+	return `${formatTokens(total)} tok${tokens?.cost === undefined || tokens.cost === 0 ? "" : ` · ${formatCost(tokens.cost)}`}`;
+};
+
 const workRow = (
 	work: WorkItemProjection,
 	attempt: AgentAttemptProjection | undefined,
 	nowMs: number,
-): WorkRowModel => ({
-	work,
-	...(attempt === undefined ? {} : { attempt }),
-	label: workLabel(work),
-	status: work.status,
-	age:
+): WorkRowModel => {
+	const age =
 		attempt?.startedAtMs === undefined
 			? "n/a"
-			: formatDuration(nowMs - attempt.startedAtMs),
-	turns: attempt === undefined ? "t0" : `t${attempt.turnCount}`,
-	tokens: formatTokens(tokenTotal(attempt)),
-	activity: displayActivity(work, attempt),
-	lastEventAgo:
-		attempt?.lastEventAtMs === undefined
-			? ""
-			: formatAgo(nowMs - attempt.lastEventAtMs),
-	stale: isStale(attempt, nowMs),
-	attention: needsAttention(work.status),
-});
+			: formatDuration(nowMs - attempt.startedAtMs);
+	const turns = attempt === undefined ? "t0" : `t${attempt.turnCount}`;
+	const tokens = formatTokens(tokenTotal(attempt));
+	const labels = compactLabels(work.labels);
+	return {
+		work,
+		...(attempt === undefined ? {} : { attempt }),
+		label: workLabel(work),
+		status: work.status,
+		age,
+		turns,
+		tokens,
+		meta: [
+			age === "n/a" ? age : `${age} active`,
+			turns,
+			...(tokens === "0" ? [] : [tokens]),
+			...(labels === "" ? [] : [labels]),
+		].join(" · "),
+		activity: displayActivity(work, attempt),
+		lastEventAgo:
+			attempt?.lastEventAtMs === undefined
+				? ""
+				: formatAgo(nowMs - attempt.lastEventAtMs),
+		stale: isStale(attempt, nowMs),
+		attention: needsAttention(work.status),
+	};
+};
 
 const attentionFrom = (
 	rows: readonly WorkRowModel[],
@@ -268,6 +299,25 @@ export const dashboardModelFrom = (
 	const throughput = tokenThroughput(projection.tokenSamples, nowMs);
 	const totalTokens = formatTokens(projection.usageTotals.tokens);
 	const nextWake = projection.scheduledWakes[0];
+	const tickIntervalMs = projection.runtime.tickIntervalMs;
+	const nextTick =
+		projection.pulse === undefined ||
+		tickIntervalMs === undefined ||
+		projection.status === "stopped" ||
+		projection.status === "shutting_down"
+			? undefined
+			: Math.ceil(
+					Math.max(0, projection.pulse.atMs + tickIntervalMs - nowMs) / 1000,
+				);
+	const recentRuns = projection.completed.slice(0, 5);
+	const duplicateLabels = new Set(
+		recentRuns
+			.map((entry) => entry.label)
+			.filter(
+				(label, _index, labels) =>
+					labels.filter((candidate) => candidate === label).length > 1,
+			),
+	);
 	return {
 		pulse: {
 			...(projection.pulse === undefined
@@ -280,6 +330,13 @@ export const dashboardModelFrom = (
 							started: projection.pulse.started,
 						},
 					}),
+			...(nextTick === undefined
+				? {}
+				: {
+						nextTick: {
+							inSeconds: nextTick,
+						},
+					}),
 			...(nextWake === undefined
 				? {}
 				: {
@@ -287,6 +344,7 @@ export const dashboardModelFrom = (
 							inSeconds: Math.ceil(
 								Math.max(0, nextWake.dueAtMs - nowMs) / 1000,
 							),
+							kind: nextWake.workKey === undefined ? "wake" : "retry",
 							...(nextWake.reason === undefined
 								? {}
 								: { reason: nextWake.reason }),
@@ -318,14 +376,30 @@ export const dashboardModelFrom = (
 				...(wake.attempt === undefined ? {} : { attempt: wake.attempt }),
 			};
 		}),
-		completed: projection.completed.slice(0, 5).map((entry) => ({
-			label: entry.label,
-			status: entry.status,
-			message: entry.message,
-			ago: formatAgo(nowMs - entry.atMs),
-			tone: entry.status === "succeeded" ? "ok" : "bad",
-			...(entry.url === undefined ? {} : { url: entry.url }),
-		})),
+		completed: recentRuns.map((entry) => {
+			const labels = compactLabels(entry.labels);
+			const run = duplicateLabels.has(entry.label)
+				? shortRunId(entry.runId)
+				: undefined;
+			const tokens = tokenMeta(entry.tokens);
+			const meta = [
+				...(labels === "" ? [] : [labels]),
+				...(entry.durationMs === undefined
+					? []
+					: [formatDuration(entry.durationMs)]),
+				...(tokens === undefined ? [] : [tokens]),
+				...(run === undefined ? [] : [`run ${run}`]),
+			].join(" · ");
+			return {
+				label: entry.label,
+				status: entry.status,
+				message: entry.message,
+				ago: formatAgo(nowMs - entry.atMs),
+				...(meta === "" ? {} : { meta }),
+				tone: entry.status === "succeeded" ? "ok" : "bad",
+				...(entry.url === undefined ? {} : { url: entry.url }),
+			};
+		}),
 		activity: projection.activity.slice(0, 20).map((entry) => ({
 			ago: formatAgo(nowMs - entry.atMs),
 			tone: entry.tone,

--- a/packages/control/src/projection.ts
+++ b/packages/control/src/projection.ts
@@ -229,11 +229,15 @@ export type AgentAttemptProjection = z.infer<
 export const completedWorkProjectionSchema = z
 	.object({
 		workKey: z.string(),
+		runId: z.string().optional(),
 		label: z.string(),
 		status: z.string(),
 		message: z.string(),
 		atMs: nonNegativeIntegerSchema,
+		durationMs: nonNegativeIntegerSchema.optional(),
 		url: z.string().optional(),
+		labels: z.array(z.string()).readonly().optional(),
+		tokens: tokenUsageProjectionSchema.optional(),
 	})
 	.strict();
 export type CompletedWorkProjection = z.infer<
@@ -967,6 +971,11 @@ const reduceAttemptCompleted = (
 	if (priorAttempt !== undefined) attempts.delete(priorAttempt.runId);
 	const priorWork = work.get(workKey);
 	const label = priorWork === undefined ? workKey : workLabel(priorWork);
+	const completedRunId = runId ?? priorAttempt?.runId;
+	const durationMs =
+		priorAttempt?.startedAtMs === undefined
+			? undefined
+			: Math.max(0, observedAtMs - priorAttempt.startedAtMs);
 	const ok = status === "succeeded";
 	if (ok) work.delete(workKey);
 	else if (priorWork !== undefined)
@@ -1008,11 +1017,19 @@ const reduceAttemptCompleted = (
 		completed: [
 			{
 				workKey,
+				...(completedRunId === undefined ? {} : { runId: completedRunId }),
 				label,
 				status,
 				message: error ?? "completed",
 				atMs: observedAtMs,
+				...(durationMs === undefined ? {} : { durationMs }),
 				...(priorWork?.url === undefined ? {} : { url: priorWork.url }),
+				...(priorWork?.labels === undefined
+					? {}
+					: { labels: priorWork.labels }),
+				...(priorAttempt?.tokens === undefined
+					? {}
+					: { tokens: priorAttempt.tokens }),
 			},
 			...projection.completed,
 		].slice(0, 20),

--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -258,9 +258,21 @@ export class PlotDashboard implements Component {
 				: `${style.text(`tick #${pulse.tick.id}`)}${style.muted(
 						` · ${pulse.tick.ago}`,
 					)}${pulse.tick.found > 0 ? style.muted(` · found ${pulse.tick.found}`) : ""}`;
+		const scheduleText = [
+			...(pulse.nextTick === undefined
+				? []
+				: [
+						`${style.muted("next tick in ")}${style.text(`${pulse.nextTick.inSeconds}s`)}`,
+					]),
+			...(pulse.nextWake === undefined
+				? []
+				: [
+						`${style.muted(`${pulse.nextWake.kind === "retry" ? "retry" : "next wake"} in `)}${style.text(`${pulse.nextWake.inSeconds}s`)}`,
+					]),
+		].join(style.dim("      "));
 		const wakeText =
-			pulse.nextWake !== undefined
-				? `${style.muted("next wake in ")}${style.text(`${pulse.nextWake.inSeconds}s`)}`
+			scheduleText.length > 0
+				? scheduleText
 				: pulse.runningCount > 0
 					? undefined
 					: style.muted("no wake scheduled");

--- a/packages/tui/src/fleet-view.ts
+++ b/packages/tui/src/fleet-view.ts
@@ -30,10 +30,9 @@ const workRowLines = (
 ): readonly DashboardLine[] => {
 	const marker = selected ? style.label("›") : " ";
 	const label = row.stale ? style.row.stale(row.label) : style.text(row.label);
-	const activeFor = row.age === "n/a" ? row.age : `${row.age} active`;
 	const first = item(`${marker} ${rowGlyph(row)} ${label}`);
 	const second = item(
-		`    ${style.stage[row.status](row.status)}${style.muted(` · ${activeFor} · ${row.turns}`)}`,
+		`    ${style.stage[row.status](row.status)}${style.muted(` · ${row.meta}`)}`,
 	);
 	const activity = quoteActivity(row.activity);
 	const third = item(
@@ -58,14 +57,15 @@ const completionRowLine = (row: CompletedRowModel): DashboardLine => {
 		row.message === "completed" || row.message === row.status
 			? ""
 			: ` · ${row.message}`;
+	const meta = row.meta === undefined ? "" : ` · ${row.meta}`;
 	return item(
-		`  ${cell(row.ago, 12, style.dim)} ${glyph} ${style.text(row.label)} ${style.muted(`${row.status}${message}`)}`,
+		`  ${cell(row.ago, 12, style.dim)} ${glyph} ${style.text(row.label)} ${style.muted(`${row.status}${message}${meta}`)}`,
 	);
 };
 
 const emptyWorkLine = (model: DashboardModel): DashboardLine => {
 	const wake = model.pulse.nextWake;
-	const suffix = wake === undefined ? "" : ` · next tick in ${wake.inSeconds}s`;
+	const suffix = wake === undefined ? "" : ` · next wake in ${wake.inSeconds}s`;
 	return item(`  no active work — watching${suffix}`, style.muted);
 };
 
@@ -145,7 +145,7 @@ export const fleetViewLines = (input: {
 	const completionBlock =
 		completionLines.length === 0
 			? []
-			: [blank(), section("Completed"), ...completionLines];
+			: [blank(), section("Recent runs"), ...completionLines];
 	const maxActivityRows =
 		model.work.length === 0 && completionLines.length === 0 ? 8 : 4;
 	const activityLines =

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -414,9 +414,44 @@ describe("PlotDashboard", () => {
 
 		expect(rendered).toContain("tick #42");
 		expect(rendered).toContain("no active work — watching");
-		expect(rendered).toContain("next tick in");
+		expect(rendered).toContain("next wake in");
 		expect(rendered).not.toContain("none\nnone");
 	});
+
+	test("shows periodic ticks separately from retry wakes", () =>
+		withFixedNow(() => {
+			const dashboard = new PlotDashboard(
+				{
+					...emptyProjection("default", "workflow", {
+						cwd: "/repo/epic",
+						cwdName: "epic",
+						skills: [],
+						skillPaths: [],
+						tickIntervalMs: 10_000,
+					}),
+					status: "running",
+					pulse: {
+						tickId: 42,
+						atMs: fixedNowMs - 3_000,
+						found: 0,
+						started: 0,
+					},
+					scheduledWakes: [
+						{
+							dueAtMs: fixedNowMs + 26_000,
+							delayMs: 30_000,
+							workKey: "source:item:42",
+						},
+					],
+				},
+				actions,
+			);
+
+			const rendered = stripAnsi(dashboard.render(120).join("\n"));
+
+			expect(rendered).toContain("next tick in 7s");
+			expect(rendered).toContain("retry in 26s");
+		}));
 
 	test("requires a second q to shut down and esc cancels", () => {
 		let shutdowns = 0;
@@ -495,7 +530,7 @@ describe("PlotDashboard", () => {
 			);
 
 			const rendered = stripAnsi(dashboard.render(120).join("\n"));
-			expect(rendered).toContain("Completed");
+			expect(rendered).toContain("Recent runs");
 			expect(rendered).toContain("3s ago");
 			expect(rendered).toContain("#42 Item 42 succeeded · review posted");
 

--- a/packages/tui/test/fixtures/dashboard/backoff_queue.evidence.md
+++ b/packages/tui/test/fixtures/dashboard/backoff_queue.evidence.md
@@ -3,13 +3,13 @@
 ╭─ PLOT  workflow  ◉ idle
 │
 │  0/4 agents active      0 tokens      0 tok/s ▁▁▁▁▁▁▁▁
-│  tick #44 · 5s ago · found 1      next wake in 2s
+│  tick #44 · 5s ago · found 1      retry in 2s
 │
 │
 │ ▲ ATTENTION (1)
 │   ● runner failed: rate limit exhausted
-├─ Agents · 2 scheduled
-│   no active work — watching · next tick in 2s
+├─ Work · 2 scheduled
+│   no active work — watching · next wake in 2s
 │     ↻ retry in 2s · attempt 4 · rate limit exhausted
 │     ↻ wake in 10s · poll
 │

--- a/packages/tui/test/fixtures/dashboard/backoff_queue.txt
+++ b/packages/tui/test/fixtures/dashboard/backoff_queue.txt
@@ -2,13 +2,13 @@
 ╭─ PLOT  workflow  ◉ idle                                                                                               
 │                                                                                                                       
 │  0/4 agents active      0 tokens      0 tok/s ▁▁▁▁▁▁▁▁                                                                
-│  tick #44 · 5s ago · found 1      next wake in 2s                                                                     
+│  tick #44 · 5s ago · found 1      retry in 2s                                                                         
 │                                                                                                                       
 │                                                                                                                       
 │ ▲ ATTENTION (1)                                                                                                       
 │   ● runner failed: rate limit exhausted                                                                               
 ├─ Work · 2 scheduled                                                                                                   
-│   no active work — watching · next tick in 2s                                                                         
+│   no active work — watching · next wake in 2s                                                                         
 │     ↻ retry in 2s · attempt 4 · rate limit exhausted                                                                  
 │     ↻ wake in 10s · poll                                                                                              
 │                                                                                                                       

--- a/packages/tui/test/fixtures/dashboard/idle.evidence.md
+++ b/packages/tui/test/fixtures/dashboard/idle.evidence.md
@@ -5,8 +5,8 @@
 │  0/4 agents active      0 tokens      0 tok/s ▁▁▁▁▁▁▁▁
 │  tick #42 · 3s ago      next wake in 26s
 │
-├─ Agents · 1 scheduled
-│   no active work — watching · next tick in 26s
+├─ Work · 1 scheduled
+│   no active work — watching · next wake in 26s
 │     ↻ wake in 26s · poll
 │
 ├─ Activity

--- a/packages/tui/test/fixtures/dashboard/idle.txt
+++ b/packages/tui/test/fixtures/dashboard/idle.txt
@@ -5,7 +5,7 @@
 │  tick #42 · 3s ago      next wake in 26s                                                                              
 │                                                                                                                       
 ├─ Work · 1 scheduled                                                                                                   
-│   no active work — watching · next tick in 26s                                                                        
+│   no active work — watching · next wake in 26s                                                                        
 │     ↻ wake in 26s · poll                                                                                              
 │                                                                                                                       
 ├─ Activity                                                                                                             

--- a/packages/tui/test/fixtures/dashboard/super_busy.evidence.md
+++ b/packages/tui/test/fixtures/dashboard/super_busy.evidence.md
@@ -5,12 +5,12 @@
 │  2/4 agents active      12.0k tokens      $0.0345      275 tok/s ▁▁▅█▁▇▅▁
 │  tick #43 · 1s ago · found 5
 │
-├─ Agents · 2 running
+├─ Work · 2 visible
 │ › ● #42 Item 42
-│     verifying · 5s active · t3
+│     running · 5s active · t3 · 8.0k
 │     Running: bun run check
 │   ● #43 Item 43
-│     finishing · 5s active · t3
+│     running · 5s active · t3 · 4.0k
 │     Posting review
 │
 ├─ Activity

--- a/packages/tui/test/fixtures/dashboard/super_busy.txt
+++ b/packages/tui/test/fixtures/dashboard/super_busy.txt
@@ -6,10 +6,10 @@
 │                                                                                                                       
 ├─ Work · 2 visible                                                                                                     
 │ › ● #42 Item 42                                                                                                       
-│     running · 5s active · t3                                                                                          
+│     running · 5s active · t3 · 8.0k                                                                                   
 │     Running: bun run check                                                                                            
 │   ● #43 Item 43                                                                                                       
-│     running · 5s active · t3                                                                                          
+│     running · 5s active · t3 · 4.0k                                                                                   
 │     Posting review                                                                                                    
 │                                                                                                                       
 ├─ Activity                                                                                                             

--- a/packages/tui/test/projection.test.ts
+++ b/packages/tui/test/projection.test.ts
@@ -45,7 +45,11 @@ const workObserved = (sequence: number, status = "pending") =>
 const workRemoved = (sequence: number) =>
 	eventRecord(sequence, "work_removed", { workKey: "source:item:42" });
 
-const workStarted = (sequence: number, workKey = "source:item:42") =>
+const workStarted = (
+	sequence: number,
+	workKey = "source:item:42",
+	labels: readonly string[] = [],
+) =>
 	plotAgentEvent(sequence, {
 		type: "attempt_started",
 		run: {
@@ -57,6 +61,7 @@ const workStarted = (sequence: number, workKey = "source:item:42") =>
 				primary: "#42",
 				title: "Fix checkout totals",
 				url: "https://example.com/pr/42",
+				...(labels.length === 0 ? {} : { labels }),
 			},
 		},
 	});
@@ -154,6 +159,21 @@ const messagePartial = (sequence: number, delta: string, partial: string) =>
 			partial: {
 				role: "assistant",
 				content: [{ type: "text", text: partial }],
+			},
+		},
+	});
+
+const messageEndWithUsage = (sequence: number) =>
+	agentRunEvent(sequence, {
+		type: "message_end",
+		message: {
+			role: "assistant",
+			content: [],
+			usage: {
+				input: 1000,
+				output: 200,
+				totalTokens: 1200,
+				cost: { total: 0.42 },
 			},
 		},
 	});
@@ -270,11 +290,15 @@ describe("Plot TUI projection", () => {
 
 	test("feeds fleet activity from work lifecycle, not raw event spam", () => {
 		let projection = emptyProjection("default", "workflow");
-		projection = reduceRecord(projection, workStarted(1));
-		projection = reduceRecord(projection, bashStart(2, "bun run check"));
 		projection = reduceRecord(
 			projection,
-			plotAgentEvent(3, {
+			workStarted(1, "source:item:42", ["phase:post", "incremental"]),
+		);
+		projection = reduceRecord(projection, bashStart(2, "bun run check"));
+		projection = reduceRecord(projection, messageEndWithUsage(3));
+		projection = reduceRecord(
+			projection,
+			plotAgentEvent(4, {
 				type: "attempt_completed",
 				completion: {
 					workKey: "source:item:42",
@@ -290,10 +314,14 @@ describe("Plot TUI projection", () => {
 		expect(projection.activity[0]?.tone).toBe("ok");
 		expect(projection.completed[0]).toMatchObject({
 			workKey: "source:item:42",
+			runId: "run-1",
 			label: "#42 Fix checkout totals",
 			status: "succeeded",
 			url: "https://example.com/pr/42",
+			labels: ["phase:post", "incremental"],
+			tokens: { input: 1000, output: 200, total: 1200, cost: 0.42 },
 		});
+		expect(projection.completed[0]?.durationMs).toBeGreaterThanOrEqual(0);
 		expect(projection.completed[0]?.atMs).toBeGreaterThan(0);
 		expect(projection.debugEvents.length).toBeGreaterThanOrEqual(3);
 	});

--- a/packages/web/src/app/dashboard/web-dashboard-state.ts
+++ b/packages/web/src/app/dashboard/web-dashboard-state.ts
@@ -297,7 +297,13 @@ export const usePlotWebDashboardState = ({
 					});
 					setRoster(await client.listSessions());
 					if (sessionId !== undefined) {
-						const attached = await client.attachSession({ sessionId, role });
+						const attached = await client.attachSession({
+							sessionId,
+							role,
+							// Rebuild derived rows (tokens, recent runs) from the same
+							// Session History stream the TUI uses.
+							afterSequence: 0,
+						});
 						const snapshotProjection = projectionFromSnapshot({
 							sessionId,
 							roster,


### PR DESCRIPTION
## Summary
- run the root `plot --workflow ...` path through the TUI instead of printing usage
- keep unknown subcommands on the usage path
- add CLI coverage for both cases

## Verification
- bun run check