### PR TITLE
fix(agent): preserve active work claims

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -262,15 +262,59 @@ const applyFactProposals = (
 	return next;
 };
 
+// Reconciliation can update display metadata, but active Agent Runs stay
+// Plot-owned until completion, timeout, shutdown, or an interrupt_work proposal.
+const activeWorkRecord = (
+	run: WorkRun,
+	record: WorkRecord | undefined,
+): WorkRecord => ({
+	workKey: run.workKey,
+	sourceId: run.sourceId,
+	status: record?.status === "draining" ? "draining" : "running",
+	...optionalSubject(record?.subject ?? run.subject),
+	...(record?.display === undefined
+		? run.display === undefined
+			? {}
+			: { display: run.display }
+		: { display: record.display }),
+	...(record?.blockedReason === undefined
+		? {}
+		: { blockedReason: record.blockedReason }),
+	...(record?.operatorActions === undefined
+		? {}
+		: { operatorActions: record.operatorActions }),
+	currentRunId: run.runId,
+});
 const applyWorkProposals = (
 	work: ReadonlyMap<WorkKey, WorkRecord>,
+	running: ReadonlyMap<WorkKey, WorkRun>,
 	proposals: readonly ReconcileProposal[],
 ) => {
 	const next = new Map(work);
+	const interruptedKeys = new Set(
+		proposals.flatMap((proposal) =>
+			proposal.type === "interrupt_work" ? [proposal.workKey] : [],
+		),
+	);
 	for (const proposal of proposals) {
-		if (proposal.type === "upsert_work")
-			next.set(proposal.work.workKey, proposal.work);
-		else if (proposal.type === "remove_work") next.delete(proposal.workKey);
+		if (proposal.type === "upsert_work") {
+			const active = running.get(proposal.work.workKey);
+			next.set(
+				proposal.work.workKey,
+				active === undefined
+					? proposal.work
+					: activeWorkRecord(active, proposal.work),
+			);
+		} else if (proposal.type === "remove_work") {
+			const active = running.get(proposal.workKey);
+			if (active === undefined || interruptedKeys.has(proposal.workKey))
+				next.delete(proposal.workKey);
+			else
+				next.set(
+					proposal.workKey,
+					activeWorkRecord(active, next.get(proposal.workKey)),
+				);
+		}
 	}
 	return next;
 };
@@ -526,7 +570,7 @@ const applyReconciled = (
 		{
 			...state,
 			facts: applyFactProposals(state.facts, proposals),
-			work: applyWorkProposals(state.work, proposals),
+			work: applyWorkProposals(state.work, state.running, proposals),
 			observations: [],
 			completions: [],
 			diagnostics: [...state.diagnostics, ...diagnostics],
@@ -1262,10 +1306,16 @@ export const makePlotAgentLayer = (
 					historyLimit,
 				);
 				for (const proposal of proposals) {
-					if (proposal.type === "upsert_work")
-						publishEvent({ type: "work_observed", work: proposal.work });
-					else if (proposal.type === "remove_work")
+					if (proposal.type === "upsert_work") {
+						const work = state.work.get(proposal.work.workKey);
+						if (work !== undefined)
+							publishEvent({ type: "work_observed", work });
+					} else if (
+						proposal.type === "remove_work" &&
+						!state.work.has(proposal.workKey)
+					) {
 						publishEvent({ type: "work_removed", workKey: proposal.workKey });
+					}
 				}
 				const wakeProposals = proposals.filter(
 					(p): p is ScheduleWakeProposal => p.type === "schedule_wake",

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
 	interruptWork,
+	removeWork,
 	scheduleWake,
 	sourceId,
 	PlotAgentError,
+	upsertWork,
 	setFact,
 	subjectKey,
 	workKey,
@@ -375,12 +377,12 @@ describe("task-agnostic Plot agent", () => {
 			selectWork: () => [{ workKey: key }],
 		};
 		const agent = makeAgent([source], succeedRunner(), {
-			continuationDelayMs: 1,
+			continuationDelayMs: 20,
 		});
 		await agent.tickOnce();
 		await yieldNow();
 		const second = await agent.tickOnce();
-		await new Promise((resolve) => setTimeout(resolve, 5));
+		await new Promise((resolve) => setTimeout(resolve, 25));
 		const third = await agent.tickOnce();
 		expect(second.completions).toHaveLength(1);
 		expect(third.started).toHaveLength(1);
@@ -416,6 +418,115 @@ describe("task-agnostic Plot agent", () => {
 			expect.objectContaining({ status: "interrupted", workKey: key }),
 		);
 		expect(after.running.has(key)).toBe(false);
+	});
+
+	test("reconciliation cannot erase active running claims", async () => {
+		const subject = subjectKey("claim:1");
+		const key = workKey("claim:1");
+		let discovered = true;
+		const source: WorkSource = {
+			id: sourceId("claim-source"),
+			reconcile: () =>
+				discovered
+					? [
+							upsertWork({
+								workKey: key,
+								sourceId: sourceId("claim-source"),
+								status: "pending",
+								subject,
+							}),
+						]
+					: [removeWork(key)],
+			selectWork: ({ snapshot }) =>
+				snapshot.running.has(key) ? [] : [{ workKey: key, subject }],
+		};
+		const agent = makeAgent([source], { run: () => never() });
+		const first = await agent.tickOnce();
+		const run = first.started[0]!;
+		const observedRunning = waitForEvent(
+			agent.events(),
+			(event) =>
+				event.type === "work_observed" &&
+				event.work.workKey === key &&
+				event.work.status === "running" &&
+				event.work.currentRunId === run.runId,
+		);
+
+		const second = await agent.tickOnce();
+		await observedRunning;
+		discovered = false;
+		const third = await agent.tickOnce();
+
+		expect(second.snapshot.work.get(key)).toEqual(
+			expect.objectContaining({
+				status: "running",
+				currentRunId: run.runId,
+			}),
+		);
+		expect(third.snapshot.work.get(key)).toEqual(
+			expect.objectContaining({
+				status: "running",
+				currentRunId: run.runId,
+			}),
+		);
+		expect(third.snapshot.running.has(key)).toBe(true);
+		await agent.shutdown();
+	});
+
+	test("reconciliation can release active work when interrupting it", async () => {
+		const key = workKey("release:1");
+		let release = false;
+		const source: WorkSource = {
+			id: sourceId("release-source"),
+			reconcile: () =>
+				release ? [interruptWork(key, "gone"), removeWork(key)] : [],
+			selectWork: ({ snapshot }) =>
+				release || snapshot.running.has(key) ? [] : [{ workKey: key }],
+		};
+		const agent = makeAgent([source], { run: () => never() });
+		await agent.tickOnce();
+		release = true;
+
+		const second = await agent.tickOnce();
+
+		expect(second.completions).toContainEqual(
+			expect.objectContaining({ status: "interrupted", workKey: key }),
+		);
+		expect(second.snapshot.work.has(key)).toBe(false);
+		expect(second.snapshot.running.has(key)).toBe(false);
+		await agent.shutdown();
+	});
+
+	test("reconciliation can mark active superseded work as draining", async () => {
+		const key = workKey("drain:1");
+		let draining = false;
+		const source: WorkSource = {
+			id: sourceId("drain-source"),
+			reconcile: () => [
+				upsertWork({
+					workKey: key,
+					sourceId: sourceId("drain-source"),
+					status: draining ? "draining" : "pending",
+				}),
+			],
+			selectWork: ({ snapshot }) =>
+				snapshot.running.has(key) ? [] : [{ workKey: key }],
+		};
+		const agent = makeAgent([source], { run: () => never() });
+		const first = await agent.tickOnce();
+		const run = first.started[0]!;
+		draining = true;
+
+		const second = await agent.tickOnce();
+
+		expect(second.snapshot.work.get(key)).toEqual(
+			expect.objectContaining({
+				status: "draining",
+				currentRunId: run.runId,
+			}),
+		);
+		expect(second.snapshot.running.has(key)).toBe(true);
+		await agent.shutdown();
 	});
 
 	test("runtime snapshot keeps bounded diagnostics history", async () => {
@@ -677,13 +788,13 @@ describe("task-agnostic Plot agent", () => {
 			},
 		};
 		const agent = makeAgent([source], runner, {
-			retryInitialDelayMs: 1,
-			continuationDelayMs: 1,
+			retryInitialDelayMs: 20,
+			continuationDelayMs: 20,
 		});
 		await agent.tickOnce();
 		await yieldNow();
-		await agent.tickOnce(); // records the failure; retry due in 1ms
-		await new Promise((resolve) => setTimeout(resolve, 5));
+		await agent.tickOnce(); // records the failure and backs off
+		await new Promise((resolve) => setTimeout(resolve, 25));
 		const third = await agent.tickOnce();
 		expect(third.started).toHaveLength(1);
 		await yieldNow();

--- a/packages/control/src/dashboard-model.ts
+++ b/packages/control/src/dashboard-model.ts
@@ -166,7 +166,14 @@ const displayActivity = (
 	if (work.status === "blocked" && work.blockedReason !== undefined)
 		return work.blockedReason;
 	if (attempt === undefined) return work.status;
-	const activity = attempt.activity.trim();
+	const stream = attempt.streaming
+		? (attempt.streams.tool ??
+			attempt.streams.message ??
+			(attempt.streams.thinking === undefined
+				? undefined
+				: `Thinking · ${attempt.streams.thinking}`))
+		: undefined;
+	const activity = (stream ?? attempt.activity).trim();
 	return activity.length === 0 ? attempt.lastMeaningful : activity;
 };
 

--- a/packages/control/src/projection.ts
+++ b/packages/control/src/projection.ts
@@ -77,6 +77,15 @@ export const activeToolSchema = z
 	.strict();
 export type ActiveTool = z.infer<typeof activeToolSchema>;
 
+export const attemptStreamsSchema = z
+	.object({
+		tool: z.string().optional(),
+		thinking: z.string().optional(),
+		message: z.string().optional(),
+	})
+	.strict();
+export type AttemptStreams = z.infer<typeof attemptStreamsSchema>;
+
 export const timelineEntrySchema = z
 	.object({
 		atMs: nonNegativeIntegerSchema,
@@ -215,6 +224,7 @@ export const agentAttemptProjectionSchema = z
 		check: workCheckSchema,
 		commands: z.array(z.string()).readonly(),
 		observations: z.array(z.string()).readonly(),
+		streams: attemptStreamsSchema,
 		phases: z.array(phaseEntrySchema).readonly(),
 		timeline: z.array(timelineEntrySchema).readonly(),
 		activeTool: activeToolSchema.optional(),
@@ -345,6 +355,8 @@ const mapValues = (value: unknown): readonly unknown[] => {
 
 const inlineText = (value: string, max = 140) =>
 	value.replace(/\s+/g, " ").trim().slice(0, max);
+const inlineMessageText = (value: string, max = 120) =>
+	inlineText(value.replace(/\*\*([^*]+)\*\*/g, "$1"), max);
 
 const baseName = (path: string) => {
 	const trimmed = path.replace(/\/+$/, "");
@@ -384,31 +396,62 @@ const argTarget = (toolName: string, args: unknown): string | undefined => {
 	return text(args["path"]);
 };
 
-const messageContentText = (message: unknown): string | undefined => {
-	if (!isRecord(message)) return undefined;
-	const content = message["content"];
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return undefined;
-	const parts = content.flatMap((item) => {
-		if (!isRecord(item)) return [];
-		if (item["type"] === "text") return text(item["text"]) ?? [];
-		if (item["type"] === "thinking") return text(item["thinking"]) ?? [];
-		return [];
-	});
+interface MessageParts {
+	readonly mode: "delta" | "partial";
+	readonly thinking?: string;
+	readonly message?: string;
+}
+
+const joined = (parts: readonly string[]) => {
 	const combined = parts.join("");
-	return combined.trim().length === 0 ? undefined : combined;
+	return combined.trim().length === 0 ? undefined : inlineMessageText(combined);
 };
 
-const messageDelta = (event: Record<string, unknown>): string | undefined => {
+const messageContentParts = (
+	message: unknown,
+): Omit<MessageParts, "mode"> | undefined => {
+	if (!isRecord(message)) return undefined;
+	const content = message["content"];
+	if (typeof content === "string") {
+		const messageText = inlineMessageText(content);
+		return messageText.length === 0 ? undefined : { message: messageText };
+	}
+	if (!Array.isArray(content)) return undefined;
+	const thinking = joined(
+		content.flatMap((item) => {
+			if (!isRecord(item)) return [];
+			if (item["type"] === "thinking" || item["type"] === "reasoning")
+				return text(item["thinking"]) ?? text(item["reasoning"]) ?? [];
+			return [];
+		}),
+	);
+	const messageText = joined(
+		content.flatMap((item) => {
+			if (!isRecord(item)) return [];
+			if (item["type"] === "text") return text(item["text"]) ?? [];
+			return [];
+		}),
+	);
+	if (thinking === undefined && messageText === undefined) return undefined;
+	return {
+		...(thinking === undefined ? {} : { thinking }),
+		...(messageText === undefined ? {} : { message: messageText }),
+	};
+};
+
+const messageParts = (
+	event: Record<string, unknown>,
+): MessageParts | undefined => {
 	const ame = event["assistantMessageEvent"];
 	if (isRecord(ame)) {
-		const partial = messageContentText(ame["partial"]);
-		if (partial !== undefined) return inlineText(partial, 120);
+		const partial = messageContentParts(ame["partial"]);
+		if (partial !== undefined) return { mode: "partial", ...partial };
 		const delta = text(ame["delta"]);
-		if (delta !== undefined && delta.trim().length > 0) return delta;
+		if (delta !== undefined && delta.trim().length > 0)
+			return { mode: "delta", message: inlineMessageText(delta) };
 	}
-	const message = messageContentText(event["message"]);
-	return message === undefined ? undefined : inlineText(message, 120);
+	const message = messageContentParts(event["message"]);
+	return message === undefined ? undefined : { mode: "partial", ...message };
 };
 
 type EventPhase = "turn" | "start" | "update" | "end" | "message" | "none";
@@ -421,7 +464,7 @@ interface Classified {
 	readonly toolCallId?: string;
 	readonly isCheck: boolean;
 	readonly isError: boolean;
-	readonly delta?: string;
+	readonly message?: MessageParts;
 }
 
 const classify = (raw: unknown): Classified => {
@@ -473,8 +516,8 @@ const classify = (raw: unknown): Classified => {
 		type === "message_update" ||
 		type === "message_end"
 	) {
-		const delta = messageDelta(raw);
-		return { ...base, type, phase: "message", ...(delta ? { delta } : {}) };
+		const message = messageParts(raw);
+		return { ...base, type, phase: "message", ...(message ? { message } : {}) };
 	}
 	return { ...base, type };
 };
@@ -601,6 +644,28 @@ const prependActivity = (
 	entry: ActivityEntry,
 	max = 50,
 ) => [entry, ...items].slice(0, max);
+
+const streamText = (
+	previous: string | undefined,
+	value: string | undefined,
+	mode: MessageParts["mode"],
+) => {
+	if (value === undefined) return previous;
+	return mode === "partial"
+		? inlineMessageText(value)
+		: inlineMessageText(`${previous ?? ""}${value}`);
+};
+
+const withoutToolStream = (streams: AttemptStreams): AttemptStreams => {
+	const { tool: _tool, ...rest } = streams;
+	return rest;
+};
+
+const thinkingLine = (thinking: string | undefined) =>
+	thinking === undefined ? undefined : `Thinking · ${thinking}`;
+
+const activityFromStreams = (streams: AttemptStreams) =>
+	streams.tool ?? streams.message ?? thinkingLine(streams.thinking);
 
 const PHASE_MAX = 24;
 
@@ -732,6 +797,7 @@ const baseAgentAttempt = (
 	check: "not-run",
 	commands: [],
 	observations: [],
+	streams: {},
 	phases: [],
 	timeline: [],
 });
@@ -822,8 +888,16 @@ export const applySnapshot = (
 		asOfSequence === undefined
 			? projection.frontier
 			: Math.max(projection.frontier, asOfSequence);
+	const status =
+		projection.status === "paused" ||
+		projection.status === "shutting_down" ||
+		projection.status === "stopped" ||
+		runningValues.length === 0
+			? projection.status
+			: "running";
 	return {
 		...projection,
+		status,
 		frontier,
 		work,
 		attempts,
@@ -883,7 +957,15 @@ const reduceTickCompleted = (
 				...projection.diagnostics,
 			].slice(0, 5)
 		: projection.diagnostics;
-	return { ...projection, status: "idle", pulse, activity, diagnostics };
+	const status =
+		projection.status === "paused" ||
+		projection.status === "shutting_down" ||
+		projection.status === "stopped"
+			? projection.status
+			: projection.attempts.size > 0 || started > 0
+				? "running"
+				: "idle";
+	return { ...projection, status, pulse, activity, diagnostics };
 };
 
 const reduceWorkObserved = (
@@ -1156,34 +1238,54 @@ const reduceAgentSessionEvent = (
 			)
 		: previous.phases;
 
-	// The live "now" line — resolved here so views render it verbatim.
+	let streams = previous.streams;
+	if (classified.message !== undefined) {
+		const thinking = streamText(
+			streams.thinking,
+			classified.message.thinking,
+			classified.message.mode,
+		);
+		const message = streamText(
+			streams.message,
+			classified.message.message,
+			classified.message.mode,
+		);
+		streams = {
+			...streams,
+			...(thinking === undefined ? {} : { thinking }),
+			...(message === undefined ? {} : { message }),
+		};
+	}
+	if (classified.phase === "start" || classified.phase === "update")
+		streams = { ...streams, tool: liveLabel(kind, target) };
+	else if (classified.phase === "end") streams = withoutToolStream(streams);
+
+	// The live "now" line — resolved here so views render it verbatim while
+	// exposing split streams for richer callsites.
 	const streaming =
+		classified.phase === "turn" ||
+		classified.phase === "start" ||
 		classified.phase === "update" ||
 		(classified.phase === "message" && classified.type !== "message_end");
+	const streamActivity = activityFromStreams(streams);
 	const activity =
-		classified.phase === "message"
-			? classified.delta === undefined
-				? previous.activity
-				: previous.activityKind === "message" &&
-					  previous.streaming &&
-					  !classified.delta.startsWith(previous.activity)
-					? inlineText(`${previous.activity}${classified.delta}`, 120)
-					: inlineText(classified.delta, 120)
+		classified.phase === "end"
+			? doneLabel(kind, target, classified.isError)
 			: classified.phase === "turn"
 				? "Thinking"
-				: classified.phase === "start" || classified.phase === "update"
-					? liveLabel(kind, target)
-					: classified.phase === "end"
-						? doneLabel(kind, target, classified.isError)
-						: previous.activity;
+				: (streamActivity ?? previous.activity);
 	const activityKind =
-		classified.phase === "message"
-			? "message"
-			: classified.phase === "none"
-				? previous.activityKind
-				: classified.phase === "turn"
-					? "think"
-					: kind;
+		classified.phase === "end"
+			? kind
+			: streams.tool !== undefined
+				? kind
+				: streams.message !== undefined
+					? "message"
+					: streams.thinking !== undefined || classified.phase === "turn"
+						? "think"
+						: classified.phase === "none"
+							? previous.activityKind
+							: kind;
 
 	const lastMeaningful = timelineWorthy
 		? timelineText
@@ -1238,6 +1340,7 @@ const reduceAgentSessionEvent = (
 		check,
 		commands,
 		observations,
+		streams,
 		phases,
 		timeline,
 		...(tokens === undefined ? {} : { tokens }),

--- a/packages/tui/src/detail-view.ts
+++ b/packages/tui/src/detail-view.ts
@@ -34,6 +34,21 @@ const tokenLine = (selected: WorkRowModel): string => {
 	return parts.join(" · ");
 };
 
+const streamLines = (selected: WorkRowModel): readonly DashboardLine[] => {
+	const streams = selected.attempt?.streams;
+	if (streams === undefined) return [];
+	const lines = [
+		...(streams.tool === undefined ? [] : [`tool      ${streams.tool}`]),
+		...(streams.message === undefined ? [] : [`message   ${streams.message}`]),
+		...(streams.thinking === undefined
+			? []
+			: [`thinking  ${streams.thinking}`]),
+	];
+	return lines.length === 0
+		? []
+		: [blankDetail(), section("Streams"), ...lines.map((line) => item(line))];
+};
+
 export const detailBodyLines = (
 	selected: WorkRowModel,
 	nowMs = Date.now(),
@@ -71,6 +86,7 @@ export const detailBodyLines = (
 					: style.muted(` · ${formatAgo(nowMs - attempt.lastEventAtMs)}`)
 			}`,
 		),
+		...streamLines(selected),
 		...(attempt === undefined
 			? []
 			: [

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -61,6 +61,7 @@ const runningWork = (
 	check: "not-run",
 	commands: [],
 	observations: [],
+	streams: {},
 	phases: [],
 	timeline: [],
 	...overrides,

--- a/packages/tui/test/projection.test.ts
+++ b/packages/tui/test/projection.test.ts
@@ -163,6 +163,27 @@ const messagePartial = (sequence: number, delta: string, partial: string) =>
 		},
 	});
 
+const mixedMessagePartial = (
+	sequence: number,
+	thinking: string,
+	message: string,
+) =>
+	agentRunEvent(sequence, {
+		type: "message_update",
+		message: { role: "assistant", content: [] },
+		assistantMessageEvent: {
+			type: "text_delta",
+			delta: message,
+			partial: {
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking },
+					{ type: "text", text: message },
+				],
+			},
+		},
+	});
+
 const messageEndWithUsage = (sequence: number) =>
 	agentRunEvent(sequence, {
 		type: "message_end",
@@ -285,6 +306,7 @@ describe("Plot TUI projection", () => {
 			}),
 		);
 		expect(projection.pulse).toMatchObject({ tickId: 7, found: 1, started: 1 });
+		expect(projection.status).toBe("running");
 		expect(projection.activity[0]?.text).toContain("tick #7 found 1");
 	});
 
@@ -359,8 +381,32 @@ describe("Plot TUI projection", () => {
 
 		const work = projection.attempts.get("run-1");
 		expect(work?.activity).toBe("hello world!");
+		expect(work?.streams.message).toBe("hello world!");
 		expect(work?.streaming).toBe(true);
 		expect(work?.messageCount).toBe(3);
+	});
+
+	test("keeps thinking and prose lanes separate and replaces partials", () => {
+		let projection = emptyProjection("default", "workflow");
+		projection = reduceRecord(projection, workStarted(1));
+		projection = reduceRecord(
+			projection,
+			mixedMessagePartial(2, "**Inspecting clone progress**", "I need"),
+		);
+		projection = reduceRecord(
+			projection,
+			mixedMessagePartial(
+				3,
+				"**Inspecting clone progress**",
+				"I need the clone to finish",
+			),
+		);
+
+		const work = projection.attempts.get("run-1");
+		expect(work?.activity).toBe("I need the clone to finish");
+		expect(work?.streams.thinking).toBe("Inspecting clone progress");
+		expect(work?.streams.message).toBe("I need the clone to finish");
+		expect(work?.activity).not.toContain("Inspecting clone progressI need");
 	});
 
 	test("surfaces streaming deltas as the live activity line", () => {
@@ -510,6 +556,7 @@ describe("Plot TUI projection", () => {
 
 		expect(projection.work.has("source:item:1")).toBe(false);
 		expect(projection.work.has("source:item:2")).toBe(true);
+		expect(projection.status).toBe("running");
 		expect(projection.attempts.has("run-1")).toBe(false);
 		expect(projection.attempts.has("run-2")).toBe(true);
 	});

--- a/packages/web/src/app/dashboard/views/session-surface.tsx
+++ b/packages/web/src/app/dashboard/views/session-surface.tsx
@@ -238,7 +238,15 @@ function WorkLane({
 	const activity =
 		item.status === "blocked" && item.blockedReason !== undefined
 			? item.blockedReason
-			: (attempt?.activity ?? item.status);
+			: attempt === undefined
+				? item.status
+				: attempt.streaming
+					? (attempt.streams.tool ??
+						attempt.streams.message ??
+						(attempt.streams.thinking === undefined
+							? attempt.activity
+							: `Thinking · ${attempt.streams.thinking}`))
+					: attempt.activity;
 	const railTone =
 		item.status === "blocked"
 			? "bg-attention"
@@ -320,6 +328,7 @@ function WorkLane({
 
 			{open ? (
 				<div className="px-6 pb-6 pl-10 text-2xs">
+					{attempt === undefined ? null : <LiveStreams attempt={attempt} />}
 					{attempt !== undefined && attempt.phases.length > 0 ? (
 						<Spine attempt={attempt} />
 					) : null}
@@ -353,6 +362,31 @@ function CheckBadge({ attempt }: { attempt?: AgentAttemptProjection }) {
 	if (attempt.check === "running")
 		return <span className="text-live">check running</span>;
 	return <span>passed</span>;
+}
+
+function LiveStreams({ attempt }: { attempt: AgentAttemptProjection }) {
+	const rows = [
+		...(attempt.streams.tool === undefined
+			? []
+			: [{ label: "tool", value: attempt.streams.tool }]),
+		...(attempt.streams.message === undefined
+			? []
+			: [{ label: "message", value: attempt.streams.message }]),
+		...(attempt.streams.thinking === undefined
+			? []
+			: [{ label: "thinking", value: attempt.streams.thinking }]),
+	];
+	if (rows.length === 0) return null;
+	return (
+		<div className={cn("mb-5 grid gap-1", mono)}>
+			{rows.map((row) => (
+				<div key={row.label} className="grid grid-cols-[72px_1fr] gap-3">
+					<span className="text-t3">{row.label}</span>
+					<span className="truncate text-muted-foreground">{row.value}</span>
+				</div>
+			))}
+		</div>
+	);
 }
 
 function Spine({ attempt }: { attempt: AgentAttemptProjection }) {


### PR DESCRIPTION
## Summary
- keep active Agent Runs visible when reconciliation upserts or removes their work record without an interrupt
- allow remove_work to release a running record when paired with interrupt_work
- add agent behavior tests and harden retry/continuation timing tests

## Test
- bun run check

Dogfood target for examples/pr-review.