### PR TITLE
Fix projection wake replay and packaged daemon autostart

### DIFF
--- a/packages/control/src/projection.ts
+++ b/packages/control/src/projection.ts
@@ -1075,7 +1075,13 @@ const reduceWorkRemoved = (
 	if (key === undefined) return projection;
 	const work = new Map(projection.work);
 	work.delete(key);
-	return { ...projection, work };
+	return {
+		...projection,
+		work,
+		scheduledWakes: projection.scheduledWakes.filter(
+			(wake) => wake.workKey !== key,
+		),
+	};
 };
 
 const reduceAttemptStarted = (
@@ -1176,6 +1182,9 @@ const reduceAttemptCompleted = (
 		...projection,
 		work,
 		attempts,
+		scheduledWakes: projection.scheduledWakes.filter(
+			(wake) => wake.workKey !== workKey,
+		),
 		activity: prependActivity(projection.activity, {
 			atMs: observedAtMs,
 			tone: ok ? "ok" : "bad",
@@ -1487,6 +1496,18 @@ const reduceAgentSessionEvent = (
 	return { ...projection, usageTotals, tokenSamples, attempts };
 };
 
+const pruneScheduledWakes = (
+	projection: DashboardProjection,
+	observedAtMs: number,
+): DashboardProjection => {
+	const scheduledWakes = projection.scheduledWakes.filter(
+		(wake) => wake.dueAtMs > observedAtMs,
+	);
+	return scheduledWakes.length === projection.scheduledWakes.length
+		? projection
+		: { ...projection, scheduledWakes };
+};
+
 const reduceEventPayload = (
 	projection: DashboardProjection,
 	type: string,
@@ -1494,22 +1515,23 @@ const reduceEventPayload = (
 	sequence: number,
 	observedAtMs: number,
 ): DashboardProjection => {
-	if (type === "session_started") return { ...projection, status: "running" };
-	if (type === "session_paused") return { ...projection, status: "paused" };
-	if (type === "session_resumed") return { ...projection, status: "idle" };
+	const current = pruneScheduledWakes(projection, observedAtMs);
+	if (type === "session_started") return { ...current, status: "running" };
+	if (type === "session_paused") return { ...current, status: "paused" };
+	if (type === "session_resumed") return { ...current, status: "idle" };
 	if (type === "session_close_requested")
-		return { ...projection, status: "shutting_down" };
+		return { ...current, status: "shutting_down" };
 	if (type === "session_shutdown" || type === "session_close_completed")
-		return { ...projection, status: "stopped" };
+		return { ...current, status: "stopped", scheduledWakes: [] };
 	if (type === "tick_started")
 		return reduceTickStarted(
-			projection,
+			current,
 			isRecord(payload) ? payload["tickId"] : undefined,
 			observedAtMs,
 		);
 	if (type === "tick_completed")
 		return reduceTickCompleted(
-			projection,
+			current,
 			isRecord(payload) && payload["result"] !== undefined
 				? payload["result"]
 				: payload,
@@ -1517,48 +1539,48 @@ const reduceEventPayload = (
 		);
 	if (type === "work_observed" && isRecord(payload)) {
 		const work = isRecord(payload["work"]) ? payload["work"] : payload;
-		return reduceWorkObserved(projection, work);
+		return reduceWorkObserved(current, work);
 	}
 	if (type === "work_removed" && isRecord(payload))
-		return reduceWorkRemoved(projection, payload["workKey"]);
+		return reduceWorkRemoved(current, payload["workKey"]);
 	if (type === "attempt_started" && isRecord(payload)) {
 		const run = isRecord(payload["run"]) ? payload["run"] : payload;
-		return reduceAttemptStarted(projection, run, sequence, observedAtMs);
+		return reduceAttemptStarted(current, run, sequence, observedAtMs);
 	}
 	if (type === "attempt_completed" && isRecord(payload)) {
 		const completion = isRecord(payload["completion"])
 			? payload["completion"]
 			: payload;
-		return reduceAttemptCompleted(projection, completion, observedAtMs);
+		return reduceAttemptCompleted(current, completion, observedAtMs);
 	}
 	if (
 		(type === "agent_session_event" || type === "agent_run_event") &&
 		isRecord(payload)
 	)
-		return reduceAgentSessionEvent(projection, payload, sequence, observedAtMs);
+		return reduceAgentSessionEvent(current, payload, sequence, observedAtMs);
 	if (type === "wake_scheduled" && isRecord(payload))
-		return reduceWakeScheduled(projection, payload, observedAtMs);
+		return reduceWakeScheduled(current, payload, observedAtMs);
 	if (
 		(type === "diagnostic_recorded" || type === "diagnostic") &&
 		isRecord(payload)
 	)
 		return {
-			...projection,
-			diagnostics: [diagnosticText(payload), ...projection.diagnostics].slice(
+			...current,
+			diagnostics: [diagnosticText(payload), ...current.diagnostics].slice(
 				0,
 				5,
 			),
 		};
 	if (type === "operator_observation_recorded" && isRecord(payload))
 		return {
-			...projection,
-			activity: prependActivity(projection.activity, {
+			...current,
+			activity: prependActivity(current.activity, {
 				atMs: observedAtMs,
 				tone: "info",
 				text: `operator action ${text(payload["actionLabel"]) ?? text(payload["actionId"]) ?? "recorded"}`,
 			}),
 		};
-	return projection;
+	return current;
 };
 
 export const reduceRecord = (
@@ -1567,7 +1589,7 @@ export const reduceRecord = (
 ): DashboardProjection => {
 	if (record.kind !== "session_event") return projection;
 	const sequence = Number(record.sequence);
-	const observedAtMs = Date.now();
+	const observedAtMs = timestampMs(record.event.timestamp);
 	const summary = eventSummary(record);
 	const next: DashboardProjection = {
 		...projection,

--- a/packages/session/src/local-server-daemon.ts
+++ b/packages/session/src/local-server-daemon.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { isAbsolute } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { ensureLocalControlToken } from "./local-server-auth.js";
 import {
@@ -45,15 +46,33 @@ const signalProcess = (pid: number, signal: NodeJS.Signals): void => {
 	}
 };
 
-const currentPlotServeCommand = (): { command: string; args: string[] } => {
-	const override = process.env["PLOT_LOCAL_SERVER_COMMAND"];
+const looksLikeScriptPath = (value: string) =>
+	isAbsolute(value) ||
+	value.startsWith("./") ||
+	value.startsWith("../") ||
+	value.includes("/") ||
+	value.includes("\\");
+
+export const currentPlotServeCommand = (
+	input: {
+		readonly argv?: readonly string[];
+		readonly execPath?: string;
+		readonly override?: string;
+	} = {},
+): { command: string; args: string[] } => {
+	const override = input.override ?? process.env["PLOT_LOCAL_SERVER_COMMAND"];
 	if (override !== undefined && override.trim() !== "") {
 		const [command, ...args] = override.trim().split(/\s+/);
 		if (command !== undefined) return { command, args };
 	}
-	const entrypoint = process.argv[1];
-	const exec = process.execPath;
-	if (entrypoint !== undefined && entrypoint !== exec)
+	const argv = input.argv ?? process.argv;
+	const exec = input.execPath ?? process.execPath;
+	const entrypoint = argv[1];
+	if (
+		entrypoint !== undefined &&
+		entrypoint !== exec &&
+		looksLikeScriptPath(entrypoint)
+	)
 		return { command: exec, args: [entrypoint, "_serve"] };
 	return { command: exec, args: ["_serve"] };
 };

--- a/packages/session/test/local-server.test.ts
+++ b/packages/session/test/local-server.test.ts
@@ -10,6 +10,7 @@ import {
 	writeLocalPlotServerMetadata,
 } from "../src/local-server-metadata.js";
 import { resolveLocalPlotServerPaths } from "../src/local-server-paths.js";
+import { currentPlotServeCommand } from "../src/local-server-daemon.js";
 import { startLocalPlotServer } from "../src/local-server.js";
 import {
 	applyStoppedOneshotRetention,
@@ -72,6 +73,33 @@ const waitForMessage = (ws: WebSocket): Promise<unknown> =>
 	});
 
 describe("Local Plot Server", () => {
+	test("daemon command keeps source entrypoints but not compiled CLI args", () => {
+		expect(
+			currentPlotServeCommand({
+				execPath: "/usr/local/bin/bun",
+				argv: ["bun", "./packages/cli/src/main.ts", "tui"],
+			}),
+		).toEqual({
+			command: "/usr/local/bin/bun",
+			args: ["./packages/cli/src/main.ts", "_serve"],
+		});
+		expect(
+			currentPlotServeCommand({
+				execPath: "/usr/local/bin/bun",
+				argv: ["bun", "packages/cli/src/main.ts", "tui"],
+			}),
+		).toEqual({
+			command: "/usr/local/bin/bun",
+			args: ["packages/cli/src/main.ts", "_serve"],
+		});
+		expect(
+			currentPlotServeCommand({
+				execPath: "/tmp/npm/plot",
+				argv: ["/tmp/npm/plot", "tui", "--workflow", "WORKFLOW.md"],
+			}),
+		).toEqual({ command: "/tmp/npm/plot", args: ["_serve"] });
+	});
+
 	test("generates a persistent local token and rejects missing or wrong tokens", async () => {
 		const paths = await tmpPaths();
 		const token = await ensureLocalControlToken(paths);

--- a/packages/tui/test/projection.test.ts
+++ b/packages/tui/test/projection.test.ts
@@ -13,6 +13,7 @@ const eventRecord = (
 	sequence: number,
 	type: string,
 	payload: unknown,
+	timestamp = "2026-06-15T00:00:00.000Z",
 ): PlotServerRecord => ({
 	protocol: plotProtocolVersion,
 	kind: "session_event",
@@ -23,7 +24,7 @@ const eventRecord = (
 		sessionId: "default",
 		epoch: "epoch-1",
 		sequence,
-		timestamp: "2026-06-15T00:00:00.000Z",
+		timestamp,
 		type,
 		payload,
 	},
@@ -382,6 +383,60 @@ describe("Plot TUI projection", () => {
 		expect(projection.pulse).toMatchObject({ tickId: 7, found: 1, started: 1 });
 		expect(projection.status).toBe("running");
 		expect(projection.activity[0]?.text).toContain("tick #7 found 1");
+	});
+
+	test("replays scheduled wakes from Session History time", () => {
+		const timestamp = "2026-06-15T00:00:00.000Z";
+		let projection = emptyProjection("default", "workflow");
+		projection = reduceRecord(
+			projection,
+			eventRecord(
+				1,
+				"wake_scheduled",
+				{ delayMs: 5_000, reason: "retry", workKey: "source:item:42" },
+				timestamp,
+			),
+		);
+
+		expect(projection.scheduledWakes).toEqual([
+			{
+				dueAtMs: Date.parse(timestamp) + 5_000,
+				delayMs: 5_000,
+				reason: "retry",
+				workKey: "source:item:42",
+			},
+		]);
+	});
+
+	test("drops scheduled wakes when later history makes them stale", () => {
+		let projection = emptyProjection("default", "workflow");
+		projection = reduceRecord(
+			projection,
+			eventRecord(1, "wake_scheduled", {
+				delayMs: 1_000,
+				workKey: "source:item:42",
+			}),
+		);
+		projection = reduceRecord(
+			projection,
+			eventRecord(2, "tick_started", { tickId: 2 }, "2026-06-15T00:00:02.000Z"),
+		);
+		expect(projection.scheduledWakes).toEqual([]);
+
+		projection = reduceRecord(
+			projection,
+			eventRecord(3, "wake_scheduled", {
+				delayMs: 60_000,
+				workKey: "source:item:42",
+			}),
+		);
+		projection = reduceRecord(
+			projection,
+			eventRecord(4, "attempt_completed", {
+				completion: { workKey: "source:item:42", status: "succeeded" },
+			}),
+		);
+		expect(projection.scheduledWakes).toEqual([]);
 	});
 
 	test("feeds fleet activity from work lifecycle, not raw event spam", () => {


### PR DESCRIPTION
## Summary
- replay scheduled wakes from Session History timestamps instead of wall-clock receipt time
- prune due wakes and clear work-scoped wakes when work is removed or completes
- fix packaged CLI daemon autostart so `plot tui` / `npx plot-ai` spawn `_serve` instead of replaying user CLI args

## Test
- bun run check
- bun run release:local --version 0.0.0-test --skip-check --out /tmp/plot-release-test --force
