### PR TITLE
fix(session): clear stale run ids from snapshots

### DIFF
--- a/packages/session/src/projection-parts/work.ts
+++ b/packages/session/src/projection-parts/work.ts
@@ -30,7 +30,7 @@ export const displayWork = (
 	const url = str(d["url"]);
 	const version = str(d["version"]);
 	const blockedReason = str(work["blockedReason"]);
-	const currentRunId = str(work["currentRunId"]) ?? previous?.currentRunId;
+	const currentRunId = str(work["currentRunId"]);
 	if (subject !== undefined) item.subject = subject;
 	if (subtitle !== undefined) item.subtitle = subtitle;
 	if (url !== undefined) item.url = url;

--- a/packages/session/test/projection.test.ts
+++ b/packages/session/test/projection.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+	applySnapshot,
 	emptyProjection,
 	hydrateDashboardProjection,
 	rebuildProjectionFromEventLog,
@@ -63,6 +64,44 @@ test("projection JSON helpers round-trip map fields", () => {
 	expect(hydrated.attempts.get("run-1")?.activeTools?.get("tool-1")?.kind).toBe(
 		"run",
 	);
+});
+
+test("snapshot clears stale current run ids", () => {
+	const live = {
+		...emptyProjection("session-1", "workflow"),
+		work: new Map([
+			[
+				"work-1",
+				{
+					workKey: "work-1",
+					sourceId: "source-1",
+					title: "Work 1",
+					labels: [],
+					status: "running" as const,
+					currentRunId: "run-1",
+				},
+			],
+		]),
+	};
+
+	const repaired = applySnapshot(live, {
+		asOfSequence: 2,
+		snapshot: {
+			work: {
+				"work-1": {
+					workKey: "work-1",
+					sourceId: "source-1",
+					status: "done",
+					display: { title: "Work 1" },
+				},
+			},
+			running: {},
+		},
+	});
+
+	expect(repaired.work.get("work-1")?.status).toBe("done");
+	expect(repaired.work.get("work-1")?.currentRunId).toBeUndefined();
+	expect(repaired.attempts.size).toBe(0);
 });
 
 test("session_started starts a fresh live projection window", () => {


### PR DESCRIPTION
## Summary
- stop projection repair from preserving stale currentRunId values when authoritative snapshots say no run is active
- add regression coverage for snapshot repair after a completed run

## Test
- bun run check