### PR TITLE
fix(session): name agent events in debug projection

### DIFF
--- a/packages/session/src/projection-parts/events.ts
+++ b/packages/session/src/projection-parts/events.ts
@@ -9,9 +9,17 @@ import type {
 } from "./types.js";
 import { displayWork, workLabel } from "./work.js";
 
+const debugEventName = (e: ProjectableEvent) => {
+	const inner = isRecord(e.event) ? str(e.event["type"]) : undefined;
+	return [str(e.kind), str(e.type) ?? inner].filter(Boolean).join(":");
+};
+
 const debug = (p: DashboardProjection, e: ProjectableEvent) => ({
 	...p,
-	debugEvents: cap([`${e.sequence} ${e.type}`, ...p.debugEvents], 200),
+	debugEvents: cap(
+		[`${e.sequence} ${debugEventName(e)}`, ...p.debugEvents],
+		200,
+	),
 });
 
 export const reduceEvent = (

--- a/packages/session/test/projection.test.ts
+++ b/packages/session/test/projection.test.ts
@@ -3,6 +3,7 @@ import {
 	emptyProjection,
 	hydrateDashboardProjection,
 	rebuildProjectionFromEventLog,
+	reduceProjectableEvent,
 	serializeDashboardProjection,
 } from "../src/projection.js";
 
@@ -63,6 +64,22 @@ test("projection JSON helpers round-trip map fields", () => {
 	expect(hydrated.attempts.get("run-1")?.activeTools?.get("tool-1")?.kind).toBe(
 		"run",
 	);
+});
+
+test("debug events name agent event payloads", () => {
+	const projection = reduceProjectableEvent(
+		emptyProjection("session-1", "workflow"),
+		{
+			kind: "agent_event",
+			sessionId: "session-1",
+			sequence: 1,
+			timestamp: "2026-06-29T10:00:00.000Z",
+			runId: "run-1",
+			event: { type: "turn_start" },
+		},
+	);
+
+	expect(projection.debugEvents[0]).toBe("1 agent_event:turn_start");
 });
 
 test("session_started starts a fresh live projection window", () => {


### PR DESCRIPTION
## Summary
- render agent event debug rows as agent_event:<inner type> instead of undefined
- add regression coverage for agent-event debug labels

## Test
- bun run check