### PR TITLE
fix(session): keep labels on completed work

### DIFF
--- a/packages/session/src/projection-parts/events.ts
+++ b/packages/session/src/projection-parts/events.ts
@@ -144,6 +144,7 @@ export const reduceEvent = (
 				? {}
 				: { durationMs: at(e) - a.startedAtMs }),
 			...(item?.url ? { url: item.url } : {}),
+			...(item?.labels.length ? { labels: item.labels } : {}),
 			...(a?.tokens ? { tokens: a.tokens } : {}),
 		};
 		return {

--- a/packages/session/test/projection.test.ts
+++ b/packages/session/test/projection.test.ts
@@ -3,6 +3,7 @@ import {
 	emptyProjection,
 	hydrateDashboardProjection,
 	rebuildProjectionFromEventLog,
+	reduceProjectableEvent,
 	serializeDashboardProjection,
 } from "../src/projection.js";
 
@@ -63,6 +64,41 @@ test("projection JSON helpers round-trip map fields", () => {
 	expect(hydrated.attempts.get("run-1")?.activeTools?.get("tool-1")?.kind).toBe(
 		"run",
 	);
+});
+
+test("completed work keeps source display labels", () => {
+	const base = emptyProjection("session-1", "workflow");
+	const started = reduceProjectableEvent(base, {
+		kind: "session_event",
+		sessionId: "session-1",
+		sequence: 1,
+		timestamp: "2026-06-29T10:00:00.000Z",
+		type: "attempt_started",
+		payload: {
+			run: {
+				runId: "run-1",
+				workKey: "work-1",
+				sourceId: "source-1",
+				display: { title: "Work 1", labels: ["done"] },
+			},
+		},
+	});
+	const completed = reduceProjectableEvent(started, {
+		kind: "session_event",
+		sessionId: "session-1",
+		sequence: 2,
+		timestamp: "2026-06-29T10:00:01.000Z",
+		type: "attempt_completed",
+		payload: {
+			completion: {
+				runId: "run-1",
+				workKey: "work-1",
+				status: "succeeded",
+			},
+		},
+	});
+
+	expect(completed.completed[0]?.labels).toEqual(["done"]);
 });
 
 test("session_started starts a fresh live projection window", () => {


### PR DESCRIPTION
## Summary
- carry work display labels into completed work projection rows
- add regression coverage for labeled completed work

## Test
- bun run check