### PR TITLE
fix(session): keep projection frontier finite

### DIFF
--- a/packages/session/src/projection.ts
+++ b/packages/session/src/projection.ts
@@ -144,10 +144,12 @@ export const reduceProjectableEvent = (
 	projection: DashboardProjection,
 	event: ProjectableEvent,
 ): DashboardProjection => {
-	if (Number(event.sequence) <= projection.frontier) return projection;
+	const sequence = Number(event.sequence);
+	if (!Number.isFinite(sequence)) return reduceEvent(projection, event);
+	if (sequence <= projection.frontier) return projection;
 	return {
 		...reduceEvent(projection, event),
-		frontier: Number(event.sequence),
+		frontier: sequence,
 	};
 };
 

--- a/packages/session/test/projection.test.ts
+++ b/packages/session/test/projection.test.ts
@@ -3,6 +3,7 @@ import {
 	emptyProjection,
 	hydrateDashboardProjection,
 	rebuildProjectionFromEventLog,
+	reduceProjectableEvent,
 	serializeDashboardProjection,
 } from "../src/projection.js";
 
@@ -63,6 +64,21 @@ test("projection JSON helpers round-trip map fields", () => {
 	expect(hydrated.attempts.get("run-1")?.activeTools?.get("tool-1")?.kind).toBe(
 		"run",
 	);
+});
+
+test("malformed event sequence does not poison the projection frontier", () => {
+	const projection = reduceProjectableEvent(
+		emptyProjection("session-1", "workflow"),
+		{
+			kind: "session_event",
+			sessionId: "session-1",
+			timestamp: "2026-06-29T10:00:00.000Z",
+			type: "session_started",
+		},
+	);
+
+	expect(projection.status).toBe("running");
+	expect(projection.frontier).toBe(0);
 });
 
 test("session_started starts a fresh live projection window", () => {


### PR DESCRIPTION
## Summary
- avoid writing NaN into the dashboard projection frontier when an event lacks a numeric sequence
- keep reducing the event while leaving the frontier unchanged
- add regression coverage for malformed event records

## Test
- bun run check