### PR TITLE
fix(session): ignore bad active tool entries

### DIFF
--- a/packages/session/src/projection.ts
+++ b/packages/session/src/projection.ts
@@ -66,11 +66,17 @@ const serializeAttempt = (
 	};
 };
 
+const isActiveToolEntry = (value: unknown): value is [string, ActiveTool] =>
+	Array.isArray(value) &&
+	typeof value[0] === "string" &&
+	typeof value[1] === "object" &&
+	value[1] !== null;
+
 const hydrateActiveTools = (
 	value: unknown,
 ): ReadonlyMap<string, ActiveTool> | undefined => {
 	if (value === undefined) return undefined;
-	if (Array.isArray(value)) return new Map(value);
+	if (Array.isArray(value)) return new Map(value.filter(isActiveToolEntry));
 	if (typeof value === "object" && value !== null)
 		return new Map(Object.entries(value) as [string, ActiveTool][]);
 	return undefined;

--- a/packages/session/test/projection.test.ts
+++ b/packages/session/test/projection.test.ts
@@ -65,6 +65,48 @@ test("projection JSON helpers round-trip map fields", () => {
 	);
 });
 
+test("projection hydration ignores malformed active tool entries", () => {
+	const projection = emptyProjection("session-1", "workflow");
+	const hydrated = hydrateDashboardProjection({
+		...projection,
+		work: {},
+		attempts: {
+			"run-1": {
+				runId: "run-1",
+				workKey: "work-1",
+				sourceId: "source-1",
+				stage: "working",
+				startedAtSeq: 1,
+				lastEventSeq: 1,
+				turnCount: 0,
+				eventCount: 0,
+				meaningfulCount: 0,
+				toolUpdateCount: 0,
+				messageCount: 0,
+				activity: "running",
+				activityKind: "run",
+				streaming: true,
+				lastDisplay: "running",
+				check: "running",
+				commands: [],
+				observations: [],
+				streams: {},
+				phases: [],
+				timeline: [],
+				activeTools: [
+					"bad",
+					["tool-1", { kind: "run", isCheck: true }],
+				] as never,
+			},
+		},
+	});
+
+	expect(hydrated.attempts.get("run-1")?.activeTools?.size).toBe(1);
+	expect(hydrated.attempts.get("run-1")?.activeTools?.get("tool-1")?.kind).toBe(
+		"run",
+	);
+});
+
 test("session_started starts a fresh live projection window", () => {
 	const projection = rebuildProjectionFromEventLog(
 		[


### PR DESCRIPTION
## Summary
- make dashboard projection hydration tolerate malformed activeTools arrays
- keep valid active tool entries instead of throwing on one bad row
- add regression coverage for corrupt serialized activeTools data

## Test
- bun run check