### PR TITLE
perf(session): cap token sample history

### DIFF
--- a/packages/session/src/projection-parts/agent-events.ts
+++ b/packages/session/src/projection-parts/agent-events.ts
@@ -256,6 +256,8 @@ export const reduceAgentEvent = (
 		tokenSamples:
 			usageTotals === p.usageTotals
 				? p.tokenSamples
-				: [...p.tokenSamples, { atMs: when, tokens: usageTotals.tokens }],
+				: [...p.tokenSamples, { atMs: when, tokens: usageTotals.tokens }].slice(
+						-120,
+					),
 	};
 };

--- a/packages/session/test/projection.test.ts
+++ b/packages/session/test/projection.test.ts
@@ -3,6 +3,7 @@ import {
 	emptyProjection,
 	hydrateDashboardProjection,
 	rebuildProjectionFromEventLog,
+	reduceProjectableEvent,
 	serializeDashboardProjection,
 } from "../src/projection.js";
 
@@ -63,6 +64,38 @@ test("projection JSON helpers round-trip map fields", () => {
 	expect(hydrated.attempts.get("run-1")?.activeTools?.get("tool-1")?.kind).toBe(
 		"run",
 	);
+});
+
+test("projection caps token throughput samples", () => {
+	let projection = reduceProjectableEvent(
+		emptyProjection("session-1", "workflow"),
+		{
+			kind: "session_event",
+			sessionId: "session-1",
+			sequence: 1,
+			timestamp: "2026-06-29T10:00:00.000Z",
+			type: "attempt_started",
+			payload: {
+				run: { runId: "run-1", workKey: "work-1", sourceId: "source-1" },
+			},
+		},
+	);
+	for (let i = 0; i < 130; i++)
+		projection = reduceProjectableEvent(projection, {
+			kind: "agent_event",
+			sessionId: "session-1",
+			sequence: i + 2,
+			timestamp: "2026-06-29T10:00:00.000Z",
+			runId: "run-1",
+			event: {
+				type: "message_end",
+				message: { responseId: `response-${i}`, usage: { totalTokens: 1 } },
+			},
+		});
+
+	expect(projection.tokenSamples).toHaveLength(120);
+	expect(projection.tokenSamples[0]?.tokens).toBe(11);
+	expect(projection.tokenSamples.at(-1)?.tokens).toBe(130);
 });
 
 test("session_started starts a fresh live projection window", () => {


### PR DESCRIPTION
## Summary
- cap dashboard token throughput samples to the latest 120 entries
- keep total usage accounting unchanged
- add regression coverage for long-running agent usage streams

## Test
- bun run check