### PR TITLE
refactor(session): probe run registry sockets before owning

### DIFF
--- a/packages/session/src/run-ipc.ts
+++ b/packages/session/src/run-ipc.ts
@@ -83,6 +83,43 @@ const handleRequest = async (runRegistry: RunRegistry, request: RunRequest) => {
 	};
 };
 
+const isSocketLive = (socketPath: string): Promise<boolean> =>
+	new Promise<boolean>((resolve, reject) => {
+		const socket = createConnection(socketPath);
+		let settled = false;
+		const finish = (value: boolean) => {
+			if (settled) return;
+			settled = true;
+			socket.removeAllListeners();
+			socket.destroy();
+			resolve(value);
+		};
+		socket.on("connect", () => finish(true));
+		socket.on("error", (error: NodeJS.ErrnoException) => {
+			if (
+				error.code === "ENOENT" ||
+				error.code === "ECONNREFUSED" ||
+				error.code === "ECONNRESET" ||
+				error.code === "EPIPE"
+			) {
+				finish(false);
+				return;
+			}
+			if (settled) return;
+			settled = true;
+			socket.removeAllListeners();
+			socket.destroy();
+			reject(error);
+		});
+	});
+
+const removeStaleSocketIfNeeded = async (socketPath: string) => {
+	if (!existsSync(socketPath)) return;
+	if (await isSocketLive(socketPath))
+		throw new Error(`run registry is already running: ${socketPath}`);
+	unlinkSync(socketPath);
+};
+
 export const startRunIpcServer = async (input: {
 	readonly options: RunIpcOptions;
 	readonly runRegistry?: RunRegistry;
@@ -93,7 +130,7 @@ export const startRunIpcServer = async (input: {
 }> => {
 	const socketPath = resolveRunIpcSocketPath(input.options);
 	await mkdir(dirname(socketPath), { recursive: true });
-	if (existsSync(socketPath)) unlinkSync(socketPath);
+	await removeStaleSocketIfNeeded(socketPath);
 	const runRegistry = input.runRegistry ?? makeRunRegistry(input.options);
 	await runRegistry.recoverAfterRestart();
 	const server = createServer((socket) => {

--- a/packages/session/test/run-registry.test.ts
+++ b/packages/session/test/run-registry.test.ts
@@ -328,6 +328,24 @@ test("runRegistry IPC opens the existing shared run registry", async () => {
 	}
 });
 
+test("runRegistry IPC refuses to replace a live socket", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "p-"));
+	const options = { cwd, runRegistryDir: join(cwd, ".plot", "runRegistry") };
+	const first = await startRunIpcServer({ options });
+	try {
+		await expect(startRunIpcServer({ options })).rejects.toThrow(
+			/run registry is already running/,
+		);
+		expect(await sendRunIpcRequest(options, { type: "list" })).toMatchObject({
+			type: "list_result",
+			ok: true,
+		});
+	} finally {
+		first.server.close();
+		await first.runRegistry.shutdown();
+	}
+});
+
 test("runRegistry IPC survives a client disconnecting from a protocol stream", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "p-"));
 	const runRegistry = new RunRegistry({


### PR DESCRIPTION
## Summary
- port pi-orchestrator style live-socket probing into Plot run IPC startup
- refuse to unlink/replace a live run-registry socket
- keep stale socket cleanup for dead sockets
- add regression coverage that a second owner cannot replace the first

## Test
- bun run check