### PR TITLE
refactor(session): split run registry daemon ownership

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import { authCommand } from "./commands/auth.js";
 import { apiCommand } from "./commands/api.js";
 import { docsCommand } from "./commands/docs.js";
 import { listModelsCommand } from "./commands/list-models.js";
+import { registryCommand } from "./commands/registry.js";
 import { runCommand } from "./commands/run.js";
 import {
 	listRunsCommand,
@@ -64,6 +65,7 @@ const subCommands = {
 	auth: authCommand,
 	docs: docsCommand,
 	run: runCommand,
+	registry: registryCommand,
 	tui: tuiCommand,
 	web: webCommand,
 	api: apiCommand,

--- a/packages/cli/src/commands/registry.ts
+++ b/packages/cli/src/commands/registry.ts
@@ -1,0 +1,69 @@
+import { existsSync, unlinkSync } from "node:fs";
+import { defineCommand } from "citty";
+import { pathArgs } from "../args.js";
+import { getCliIo } from "../cli-context.js";
+import { str } from "../options.js";
+import { resolvePlotCommand } from "../plot-command.js";
+import { startRunIpcServer } from "@plot/session/run-ipc";
+
+const serveRegistry = async (input: {
+	readonly cwd: string;
+	readonly runRegistryDir?: string;
+	readonly writeStderr?: (text: string) => Promise<void> | void;
+}) => {
+	const server = await startRunIpcServer({
+		options: {
+			cwd: input.cwd,
+			...(input.runRegistryDir === undefined
+				? {}
+				: { runRegistryDir: input.runRegistryDir }),
+			cli: resolvePlotCommand(),
+		},
+	});
+	await input.writeStderr?.(`Plot run registry: ${server.socketPath}\n`);
+	let stopping = false;
+	const shutdown = async () => {
+		if (stopping) return;
+		stopping = true;
+		server.server.close();
+		await server.runRegistry.shutdown();
+		if (existsSync(server.socketPath)) unlinkSync(server.socketPath);
+	};
+	process.once("SIGINT", () => void shutdown().then(() => process.exit(0)));
+	process.once("SIGTERM", () => void shutdown().then(() => process.exit(0)));
+	await new Promise<void>(() => {});
+};
+
+const serveCommand = defineCommand({
+	meta: {
+		name: "serve",
+		description: "Serve the shared Plot run registry daemon.",
+	},
+	args: {
+		cwd: pathArgs.cwd,
+		"registry-dir": {
+			type: "string",
+			description: "Run registry state directory.",
+			valueHint: "path",
+		},
+	},
+	run: ({ args }) => {
+		const io = getCliIo();
+		const runRegistryDir = str(args, "registry-dir");
+		return serveRegistry({
+			cwd: str(args, "cwd") ?? process.cwd(),
+			...(runRegistryDir === undefined ? {} : { runRegistryDir }),
+			...(io.writeStderr === undefined ? {} : { writeStderr: io.writeStderr }),
+		});
+	},
+});
+
+export const registryCommand = defineCommand({
+	meta: {
+		name: "registry",
+		description: "Manage the shared Plot run registry daemon.",
+	},
+	subCommands: {
+		serve: serveCommand,
+	},
+});

--- a/packages/cli/src/semantics.ts
+++ b/packages/cli/src/semantics.ts
@@ -33,4 +33,9 @@ export const cliSemantics = {
 		surface: "transport",
 		description: "Serve the Plot API for external clients.",
 	},
+	registry: {
+		audience: "machine",
+		surface: "transport",
+		description: "Manage the shared Plot run registry daemon.",
+	},
 } as const satisfies Record<string, CliCommandSemantics>;

--- a/packages/cli/src/web-gateway.ts
+++ b/packages/cli/src/web-gateway.ts
@@ -10,7 +10,7 @@ import {
 	splitJsonl,
 	type JsonlDecodeState,
 } from "@plot/session/jsonl";
-import { openRunIpc, type RunIpcOptions } from "@plot/session/run-ipc";
+import { openOrStartRunIpc, type RunIpcOptions } from "@plot/session/run-ipc";
 import type { RunRecord } from "@plot/session/run-registry";
 import {
 	emptyProjection,
@@ -315,7 +315,7 @@ const sessionEventsResponse = (input: {
 export const startPlotWebGateway = async (
 	options: PlotWebGatewayOptions,
 ): Promise<{ readonly url: string; readonly stop: () => void }> => {
-	const runIpc = await openRunIpc({
+	const runIpc = await openOrStartRunIpc({
 		cwd: options.cwd,
 		...(options.registryDir === undefined
 			? {}

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -135,6 +135,7 @@ describe("plot CLI", () => {
 		expect(output).toContain("docs");
 		expect(output).not.toContain("dynamic");
 		expect(output).toContain("run");
+		expect(output).toContain("registry");
 		expect(output).toContain("tui");
 		expect(output).toContain("web");
 		expect(output).toContain("api");

--- a/packages/cli/test/web-gateway.test.ts
+++ b/packages/cli/test/web-gateway.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { createFileEventLogStore } from "@plot/session/event-log";
+import { startRunIpcServer } from "@plot/session/run-ipc";
 import type { RunRecord } from "@plot/session/run-registry";
 import { startPlotWebGateway } from "../src/web-gateway.js";
 
@@ -16,20 +17,29 @@ const writeRuns = async (registryDir: string, runs: readonly RunRecord[]) => {
 
 const startTestGateway = async (cwd: string) => {
 	const registryDir = await mkdtemp(join(tmpdir(), "plot-runs-"));
+	const registry = await startRunIpcServer({
+		options: { cwd, runRegistryDir: registryDir },
+	});
+	const gateway = await startPlotWebGateway({
+		cwd,
+		registryDir,
+		open: false,
+	});
 	return {
 		registryDir,
-		gateway: await startPlotWebGateway({
-			cwd,
-			registryDir,
-			open: false,
-		}),
+		gateway,
+		stop: async () => {
+			gateway.stop();
+			registry.server.close();
+			await registry.runRegistry.shutdown();
+		},
 	};
 };
 
 describe("Plot web gateway", () => {
 	test("serves runs", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "plot-web-gateway-"));
-		const { gateway, registryDir } = await startTestGateway(dir);
+		const { gateway, registryDir, stop } = await startTestGateway(dir);
 		try {
 			await writeRuns(registryDir, [
 				{
@@ -54,13 +64,13 @@ describe("Plot web gateway", () => {
 				lastSequence: 3,
 			});
 		} finally {
-			gateway.stop();
+			await stop();
 		}
 	});
 
 	test("streams run catalog updates as one SSE", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "plot-web-gateway-"));
-		const { gateway, registryDir } = await startTestGateway(dir);
+		const { gateway, registryDir, stop } = await startTestGateway(dir);
 		await writeRuns(registryDir, [
 			{
 				id: "run-1",
@@ -96,7 +106,7 @@ describe("Plot web gateway", () => {
 		} finally {
 			clearTimeout(timeout);
 			abort.abort();
-			gateway.stop();
+			await stop();
 		}
 	});
 
@@ -111,7 +121,7 @@ describe("Plot web gateway", () => {
 			type: "session_started",
 			payload: { ok: true },
 		});
-		const { gateway, registryDir } = await startTestGateway(dir);
+		const { gateway, registryDir, stop } = await startTestGateway(dir);
 		await writeRuns(registryDir, [
 			{
 				id: "run-1",
@@ -150,7 +160,7 @@ describe("Plot web gateway", () => {
 		} finally {
 			clearTimeout(timeout);
 			abort.abort();
-			gateway.stop();
+			await stop();
 		}
 	});
 
@@ -166,7 +176,7 @@ describe("Plot web gateway", () => {
 			type: "session_tick",
 			payload: { tickId: 7 },
 		});
-		const { gateway, registryDir } = await startTestGateway(dir);
+		const { gateway, registryDir, stop } = await startTestGateway(dir);
 		try {
 			await writeRuns(registryDir, [
 				{
@@ -194,7 +204,7 @@ describe("Plot web gateway", () => {
 			expect(body.projection?.frontier).toBe(2);
 			expect(body.projection?.work).toEqual({});
 		} finally {
-			gateway.stop();
+			await stop();
 		}
 	});
 });

--- a/packages/session/src/run-ipc.ts
+++ b/packages/session/src/run-ipc.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { createConnection, createServer, type Server } from "node:net";
@@ -317,25 +318,75 @@ export const openRunIpc = async (
 	readonly owned: boolean;
 	readonly close: () => Promise<void>;
 }> => {
+	await sendRunIpcRequest(options, { type: "list" });
+	return {
+		runRegistry: createRunIpcClient(options),
+		socketPath: resolveRunIpcSocketPath(options),
+		owned: false,
+		close: async () => {},
+	};
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const waitForRunIpc = async (
+	options: RunIpcOptions,
+	timeoutMs = 5_000,
+): Promise<void> => {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() <= deadline) {
+		try {
+			// eslint-disable-next-line no-await-in-loop -- poll until the daemon accepts requests.
+			await sendRunIpcRequest(options, { type: "list" });
+			return;
+		} catch (error) {
+			lastError = error;
+			// eslint-disable-next-line no-await-in-loop -- bounded retry delay.
+			await sleep(50);
+		}
+	}
+	throw new Error(`run registry did not start: ${errorMessage(lastError)}`);
+};
+
+export const startRunIpcDaemon = async (
+	options: RunIpcOptions,
+): Promise<void> => {
+	if (options.cli === undefined)
+		throw new Error(
+			"run registry daemon is not running; run `plot registry serve`",
+		);
+	const args = [
+		...options.cli.args,
+		"registry",
+		"serve",
+		"--cwd",
+		options.cwd,
+		...(options.runRegistryDir === undefined
+			? []
+			: ["--registry-dir", options.runRegistryDir]),
+	];
+	const child = spawn(options.cli.command, args, {
+		cwd: options.cwd,
+		detached: true,
+		stdio: "ignore",
+	});
+	child.unref();
+	await waitForRunIpc(options);
+};
+
+export const openOrStartRunIpc = async (
+	options: RunIpcOptions,
+): Promise<{
+	readonly runRegistry: RunRegistryRuntime;
+	readonly socketPath: string;
+	readonly owned: boolean;
+	readonly close: () => Promise<void>;
+}> => {
 	try {
-		await sendRunIpcRequest(options, { type: "list" });
-		return {
-			runRegistry: createRunIpcClient(options),
-			socketPath: resolveRunIpcSocketPath(options),
-			owned: false,
-			close: async () => {},
-		};
+		return await openRunIpc(options);
 	} catch {
-		const server = await startRunIpcServer({ options });
-		return {
-			runRegistry: server.runRegistry,
-			socketPath: server.socketPath,
-			owned: true,
-			close: async () => {
-				server.server.close();
-				await server.runRegistry.shutdown();
-				if (existsSync(server.socketPath)) unlinkSync(server.socketPath);
-			},
-		};
+		await startRunIpcDaemon(options);
+		return openRunIpc(options);
 	}
 };

--- a/packages/session/test/run-registry.test.ts
+++ b/packages/session/test/run-registry.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
@@ -14,6 +15,7 @@ import {
 import type { RunChildProcess } from "../src/run-process.js";
 import {
 	openRunIpc,
+	resolveRunIpcSocketPath,
 	sendRunIpcRequest,
 	startRunIpcServer,
 } from "../src/run-ipc.js";
@@ -269,6 +271,13 @@ test("runRegistry attach replays only durable event log records after a sequence
 			record.kind === "event" ? [record.sequence] : [],
 		),
 	).toEqual([21, 22, 23, 24, 25, 26, 27, 28, 29, 30]);
+});
+
+test("runRegistry IPC does not start an in-process registry", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "p-"));
+	const options = { cwd, runRegistryDir: join(cwd, ".plot", "runRegistry") };
+	await expect(openRunIpc(options)).rejects.toThrow();
+	expect(existsSync(resolveRunIpcSocketPath(options))).toBe(false);
 });
 
 test("runRegistry IPC opens the existing shared run registry", async () => {

--- a/packages/tui/src/plot-tui.ts
+++ b/packages/tui/src/plot-tui.ts
@@ -3,7 +3,7 @@ import { basename } from "node:path";
 import { errorMessage } from "@plot/common/primitives";
 import { ProcessTerminal, TUI, matchesKey } from "./terminal-ui.js";
 import type { CreateSessionHostOptions } from "@plot/session/host";
-import { openRunIpc, type RunIpcOptions } from "@plot/session/run-ipc";
+import { openOrStartRunIpc, type RunIpcOptions } from "@plot/session/run-ipc";
 import {
 	sessionProtocolVersion,
 	type ClientRequest,
@@ -64,7 +64,7 @@ const initialProjection = (input: {
 	);
 
 export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
-	const runIpc = await openRunIpc({
+	const runIpc = await openOrStartRunIpc({
 		cwd: options.cwd,
 		...(options.cli === undefined ? {} : { cli: options.cli }),
 	});


### PR DESCRIPTION
## Summary
- add `plot registry serve` as the explicit run-registry daemon
- make `openRunIpc` connect-only instead of becoming an in-process owner
- let TUI/web bootstrap the external daemon through the CLI when none is running
- update web tests to connect to an existing registry server

## Test
- bun run check

Stacked on #142 for stale socket probing.