### PR TITLE
fix(cli): harden web gateway requests

### DIFF
--- a/packages/cli/src/web-gateway.ts
+++ b/packages/cli/src/web-gateway.ts
@@ -34,8 +34,9 @@ export interface PlotWebGatewayOptions {
 	readonly cli?: RunIpcOptions["cli"];
 }
 
-const text = (body: unknown) =>
+const text = (body: unknown, init: ResponseInit = {}) =>
 	new Response(JSON.stringify(body), {
+		...init,
 		headers: { "content-type": "application/json; charset=utf-8" },
 	});
 
@@ -325,69 +326,80 @@ export const startPlotWebGateway = async (
 	const server = Bun.serve({
 		hostname: options.host ?? "127.0.0.1",
 		port: options.port ?? 0,
+		idleTimeout: 255,
 		async fetch(request) {
-			const url = new URL(request.url);
-			if (url.pathname === "/api/runs/events")
-				return runCatalogEventsResponse({
-					request,
-					listRuns: () => runIpc.runRegistry.list(),
-				});
-			if (url.pathname === "/api/runs" && request.method === "POST") {
-				const body = await parseCreateRunBody(request);
-				const run = await runIpc.runRegistry.spawn({
-					cwd: body.cwd ?? options.cwd,
-					...(body.workflowPath !== undefined
-						? { workflowPath: body.workflowPath }
-						: options.workflowPath === undefined
-							? {}
-							: { workflowPath: options.workflowPath }),
-					...(body.label === undefined ? {} : { label: body.label }),
-				});
-				return text({ run });
-			}
-			const stopPath = /^\/api\/runs\/([^/]+)$/.exec(url.pathname);
-			if (stopPath !== null && request.method === "DELETE") {
-				const run = await runIpc.runRegistry.stop(
-					decodeURIComponent(stopPath[1] ?? ""),
+			try {
+				const url = new URL(request.url);
+				if (url.pathname === "/api/runs/events")
+					return runCatalogEventsResponse({
+						request,
+						listRuns: () => runIpc.runRegistry.list(),
+					});
+				if (url.pathname === "/api/runs" && request.method === "POST") {
+					const body = await parseCreateRunBody(request);
+					const run = await runIpc.runRegistry.spawn({
+						cwd: body.cwd ?? options.cwd,
+						...(body.workflowPath !== undefined
+							? { workflowPath: body.workflowPath }
+							: options.workflowPath === undefined
+								? {}
+								: { workflowPath: options.workflowPath }),
+						...(body.label === undefined ? {} : { label: body.label }),
+					});
+					return text({ run });
+				}
+				const stopPath = /^\/api\/runs\/([^/]+)$/.exec(url.pathname);
+				if (stopPath !== null && request.method === "DELETE") {
+					const run = await runIpc.runRegistry.stop(
+						decodeURIComponent(stopPath[1] ?? ""),
+					);
+					return run === undefined
+						? new Response("run not found", { status: 404 })
+						: text({ run });
+				}
+				if (url.pathname === "/api/runs") {
+					const runs = await runIpc.runRegistry
+						.list()
+						.then((value) => ({ ok: true as const, value }))
+						.catch((error: unknown) => ({ ok: false as const, error }));
+					return runs.ok
+						? text({ runs: runs.value })
+						: text({ error: String(runs.error) }, { status: 503 });
+				}
+				const eventPath = /^\/api\/runs\/([^/]+)\/events$/.exec(url.pathname);
+				if (eventPath !== null) {
+					const after = parseAfterSequence({
+						header: request.headers.get("last-event-id"),
+						query: url.searchParams.get("after"),
+					});
+					if (after === undefined)
+						return text({ error: "invalid after sequence" });
+					const id = decodeURIComponent(eventPath[1] ?? "");
+					const run = await runIpc.runRegistry.status(id);
+					if (run === undefined)
+						return new Response("run not found", { status: 404 });
+					return sessionEventsResponse({
+						request,
+						records: runIpc.runRegistry.attachRecords(id, after),
+					});
+				}
+				const projectionPath = /^\/api\/runs\/([^/]+)\/projection$/.exec(
+					url.pathname,
 				);
-				return run === undefined
-					? new Response("run not found", { status: 404 })
-					: text({ run });
+				if (projectionPath !== null) {
+					const run = await runIpc.runRegistry.status(
+						decodeURIComponent(projectionPath[1] ?? ""),
+					);
+					if (run === undefined)
+						return new Response("run not found", { status: 404 });
+					return runProjectionResponse(run);
+				}
+				if (url.pathname === "/api/health")
+					return text({ ok: true, socketPath: runIpc.socketPath });
+				return assetResponse(url.pathname);
+			} catch (error) {
+				return text({ error: String(error) }, { status: 503 });
 			}
-			if (url.pathname === "/api/runs") {
-				return text({ runs: await runIpc.runRegistry.list() });
-			}
-			const eventPath = /^\/api\/runs\/([^/]+)\/events$/.exec(url.pathname);
-			if (eventPath !== null) {
-				const after = parseAfterSequence({
-					header: request.headers.get("last-event-id"),
-					query: url.searchParams.get("after"),
-				});
-				if (after === undefined)
-					return text({ error: "invalid after sequence" });
-				const id = decodeURIComponent(eventPath[1] ?? "");
-				const run = await runIpc.runRegistry.status(id);
-				if (run === undefined)
-					return new Response("run not found", { status: 404 });
-				return sessionEventsResponse({
-					request,
-					records: runIpc.runRegistry.attachRecords(id, after),
-				});
-			}
-			const projectionPath = /^\/api\/runs\/([^/]+)\/projection$/.exec(
-				url.pathname,
-			);
-			if (projectionPath !== null) {
-				const run = await runIpc.runRegistry.status(
-					decodeURIComponent(projectionPath[1] ?? ""),
-				);
-				if (run === undefined)
-					return new Response("run not found", { status: 404 });
-				return runProjectionResponse(run);
-			}
-			if (url.pathname === "/api/health")
-				return text({ ok: true, socketPath: runIpc.socketPath });
-			return assetResponse(url.pathname);
 		},
 	});
 	const url = `http://${server.hostname}:${server.port}/`;

--- a/packages/session/src/run-ipc.ts
+++ b/packages/session/src/run-ipc.ts
@@ -207,14 +207,25 @@ export const sendRunIpcRequest = async (
 	new Promise((resolve, reject) => {
 		const socket = createConnection(resolveRunIpcSocketPath(options));
 		let buffer = "";
+		let settled = false;
+		const finish = (work: () => void) => {
+			if (settled) return;
+			settled = true;
+			socket.removeAllListeners();
+			socket.destroy();
+			work();
+		};
 		socket.on("connect", () => write(socket, request));
-		socket.on("error", reject);
+		socket.on("error", (error) => finish(() => reject(error)));
 		socket.on("data", (chunk: Buffer | string) => {
 			buffer += chunk.toString();
 			const index = buffer.indexOf("\n");
 			if (index === -1) return;
-			resolve(decodeRunResponse(JSON.parse(buffer.slice(0, index)) as unknown));
-			socket.end();
+			finish(() =>
+				resolve(
+					decodeRunResponse(JSON.parse(buffer.slice(0, index)) as unknown),
+				),
+			);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- raise Bun web idle timeout so long-lived web requests do not kill the gateway
- return JSON 503 from API handler failures instead of surfacing raw handler errors
- settle run IPC client sockets once to avoid duplicate socket error handling

## Test
- bun run check