### PR TITLE
fix(cli): expose web docs topic

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -9,6 +9,7 @@ Start here:
   plot docs workflows
   plot docs extensions
   plot docs tui
+  plot docs web
 
 For LLM-assisted extension authoring:
   plot docs extension-prompt
@@ -22,7 +23,8 @@ export const docsCommand = defineCommand({
 	args: {
 		topic: {
 			type: "positional",
-			description: "index|quickstart|workflows|extensions|tui|extension-prompt",
+			description:
+				"index|quickstart|workflows|extensions|tui|web|extension-prompt",
 			required: false,
 		},
 	},

--- a/packages/cli/src/docs.ts
+++ b/packages/cli/src/docs.ts
@@ -8,6 +8,7 @@ const docNames = [
 	"workflows",
 	"extensions",
 	"tui",
+	"web",
 ] as const;
 export type DocName = (typeof docNames)[number];
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -357,6 +357,20 @@ describe("plot CLI", () => {
 		expect(output).not.toContain("--workflow");
 	});
 
+	test("prints web docs", async () => {
+		const stdout: string[] = [];
+		await runPlotCli(["docs", "web"], {
+			stdin: chunks([]),
+			writeStdout: (line) => {
+				stdout.push(line);
+			},
+		});
+
+		const output = stdout.join("");
+		expect(output).toContain("# Web Dashboard");
+		expect(output).toContain("plot web");
+	});
+
 	test("prints bundled extension author docs", async () => {
 		const stdout: string[] = [];
 		await runPlotCli(["docs", "extension-prompt"], {


### PR DESCRIPTION
## Summary
- add `web` to supported `plot docs` topics
- list it in docs command help/index
- cover `plot docs web`

## Test
- bun run check