### PR TITLE
fix(session): reject malformed run ipc responses

### DIFF
--- a/packages/session/src/run-ipc.ts
+++ b/packages/session/src/run-ipc.ts
@@ -230,11 +230,14 @@ export const sendRunIpcRequest = async (
 			buffer += chunk.toString();
 			const index = buffer.indexOf("\n");
 			if (index === -1) return;
-			finish(() =>
-				resolve(
-					decodeRunResponse(JSON.parse(buffer.slice(0, index)) as unknown),
-				),
-			);
+			try {
+				const response = decodeRunResponse(
+					JSON.parse(buffer.slice(0, index)) as unknown,
+				);
+				finish(() => resolve(response));
+			} catch (error) {
+				finish(() => reject(error));
+			}
 		});
 	});
 

--- a/packages/session/test/run-registry.test.ts
+++ b/packages/session/test/run-registry.test.ts
@@ -302,6 +302,28 @@ test("runRegistry IPC rejects when the socket closes before a response", async (
 	}
 });
 
+test("runRegistry IPC rejects malformed responses", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "p-"));
+	const options = { cwd, runRegistryDir: join(cwd, ".plot", "runRegistry") };
+	const socketPath = resolveRunIpcSocketPath(options);
+	await mkdir(dirname(socketPath), { recursive: true });
+	const server = createServer((socket) => socket.end("not-json\n"));
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(socketPath, () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	try {
+		await expect(
+			sendRunIpcRequest(options, { type: "list" }),
+		).rejects.toThrow();
+	} finally {
+		server.close();
+	}
+});
+
 test("runRegistry IPC opens the existing shared run registry", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "p-"));
 	const child = new FakeChild("session-shared");


### PR DESCRIPTION
## Summary
- reject one-shot run IPC requests when the peer sends malformed JSON/schema data
- cover malformed socket responses instead of letting event handlers throw

## Test
- bun run check