### PR TITLE
fix(cli): use cwd basename in web projections

### DIFF
--- a/packages/cli/src/web-gateway.ts
+++ b/packages/cli/src/web-gateway.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { open } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
 	decodeEventLogRecord,
 	type EventLogRecord,
@@ -258,7 +258,7 @@ const runProjectionResponse = async (run: RunRecord): Promise<Response> => {
 		await readRunEventLog(eventLogPath),
 		emptyProjection(run.sessionId, run.workflowName ?? "workflow", {
 			cwd: run.cwd,
-			cwdName: run.cwdName ?? run.cwd,
+			cwdName: run.cwdName ?? basename(run.cwd),
 			workflowPath: run.workflowPath ?? "WORKFLOW.md",
 			skills: [],
 			skillPaths: [],

--- a/packages/cli/test/web-gateway.test.ts
+++ b/packages/cli/test/web-gateway.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { createFileEventLogStore } from "@plot/session/event-log";
 import { startRunIpcServer } from "@plot/session/run-ipc";
@@ -187,7 +187,6 @@ describe("Plot web gateway", () => {
 					lastSeenAt: new Date().toISOString(),
 					sessionId: "default",
 					workflowName: "workflow",
-					cwdName: "project",
 					sessionDir,
 					lastSequence: 2,
 				},
@@ -199,10 +198,12 @@ describe("Plot web gateway", () => {
 				readonly projection?: {
 					readonly frontier?: number;
 					readonly work?: unknown;
+					readonly runtime?: { readonly cwdName?: string };
 				};
 			};
 			expect(body.projection?.frontier).toBe(2);
 			expect(body.projection?.work).toEqual({});
+			expect(body.projection?.runtime?.cwdName).toBe(basename(dir));
 		} finally {
 			await stop();
 		}


### PR DESCRIPTION
## Summary
- use the project directory basename when web builds a projection for runs without cwdName
- cover projection fallback runtime identity

## Test
- bun run check