### PR TITLE
fix(tui): work trail follows the newest timeline entries

### DIFF
--- a/packages/tui/src/detail-view.ts
+++ b/packages/tui/src/detail-view.ts
@@ -37,10 +37,12 @@ const workTrailLines = (
 		attempt.streaming || attempt.timeline.length === 0
 			? [{ age: "now", text: quoteActivity(selected.activity) }]
 			: [];
+	// Chronological tail: newest entries sit at the bottom, next to the live
+	// row. (toReversed().slice(-n) kept the oldest entries, so the trail froze
+	// once it outgrew the window.)
 	const history = attempt.timeline
-		.toReversed()
-		.map((entry) => ({ age: trailAge(entry.atMs, nowMs), text: entry.text }))
-		.slice(-(trailWindowRows - live.length));
+		.slice(-(trailWindowRows - live.length))
+		.map((entry) => ({ age: trailAge(entry.atMs, nowMs), text: entry.text }));
 	return [...history, ...live].map((entry) =>
 		item(`  ${cell(entry.age, 8, style.dim)} ${entry.text}`),
 	);

--- a/packages/tui/test/detail-view.test.ts
+++ b/packages/tui/test/detail-view.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import type {
+	AgentAttemptProjection,
+	WorkItemProjection,
+} from "@plot/session/projection";
+import type { WorkRowModel } from "../src/dashboard-model.js";
+import { detailBodyLines } from "../src/detail-view.js";
+
+const work: WorkItemProjection = {
+	workKey: "work-1",
+	sourceId: "source-1",
+	title: "Work 1",
+	labels: [],
+	status: "running",
+};
+
+const attempt = (timelineLength: number): AgentAttemptProjection => ({
+	runId: "run-1",
+	workKey: "work-1",
+	sourceId: "source-1",
+	stage: "working",
+	startedAtSeq: 1,
+	lastEventSeq: timelineLength,
+	turnCount: 1,
+	eventCount: timelineLength,
+	meaningfulCount: timelineLength,
+	toolUpdateCount: 0,
+	messageCount: 0,
+	activity: "working",
+	activityKind: "run",
+	streaming: false,
+	lastDisplay: "working",
+	check: "not-run",
+	commands: [],
+	observations: [],
+	streams: {},
+	phases: [],
+	timeline: Array.from({ length: timelineLength }, (_, index) => ({
+		atMs: 1000 + index,
+		text: `step-${index + 1}`,
+		kind: "run" as const,
+	})),
+});
+
+const row = (timelineLength: number): WorkRowModel => ({
+	work,
+	attempt: attempt(timelineLength),
+	label: "Work 1",
+	status: "running",
+	meta: "",
+	activity: "working",
+	lastEventAgo: "1s",
+	stale: false,
+	attention: false,
+});
+
+test("work trail shows the newest timeline entries in chronological order", () => {
+	const text = detailBodyLines(row(20), 2000)
+		.map((line) => JSON.stringify(line))
+		.join("\n");
+	// The newest entry is present; the oldest has scrolled out of the window.
+	expect(text).toContain("step-20");
+	expect(text).not.toContain("step-1\u0022");
+	expect(text.indexOf("step-19")).toBeLessThan(text.indexOf("step-20"));
+});


### PR DESCRIPTION
## Problem

`workTrailLines` renders `attempt.timeline.toReversed().slice(-(window))`. Slicing the tail of a reversed list keeps the **oldest** entries, in reverse order. The moment an attempt's timeline outgrows the nine-row window, the work trail freezes on the attempt's first steps and never shows current activity again — exactly when an operator most needs it.

## Fix

Take the chronological tail (`timeline.slice(-window)`) so the newest entries render in reading order, adjacent to the live activity row.

## Test

`detail-view.test.ts`: with a 20-entry timeline, the trail contains `step-20`, has dropped `step-1`, and orders `step-19` before `step-20`. Fails on the previous implementation.