### PR TITLE
refactor(session): remove fake safeParseDashboardProjection

### DIFF
--- a/packages/session/src/projection.ts
+++ b/packages/session/src/projection.ts
@@ -163,8 +163,3 @@ export const reduceRecord = (
 	projection: DashboardProjection,
 	input: ProjectableEventRecord,
 ): DashboardProjection => reduceProjectableEvent(projection, input.event);
-
-export const safeParseDashboardProjection = (value: unknown) => ({
-	success: true as const,
-	data: value as DashboardProjection,
-});


### PR DESCRIPTION
## What

Deletes `safeParseDashboardProjection` from `@plot/session/projection`.

## Why

```ts
export const safeParseDashboardProjection = (value: unknown) => ({
	success: true as const,
	data: value as DashboardProjection,
});
```

It is shaped like a zod-style safe parser but performs **no validation** — `success` is always `true` and `data` is a blind cast. A function like this is worse than nothing: any future caller reading the name would believe they hold a validated projection. It has zero consumers across the repo, so this is a pure deletion.

Real hydration/validation lives in `hydrateDashboardProjection`; boundary decoding belongs to the effect schemas.