### PR TITLE
feat(cli): plot prune removes ended runs and their history

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,7 @@ import { runCommand } from "./commands/run.js";
 import {
 	listRunsCommand,
 	logsRunCommand,
+	pruneRunsCommand,
 	statusRunCommand,
 	stopRunCommand,
 } from "./commands/runs.js";
@@ -73,6 +74,7 @@ const subCommands = {
 	status: statusRunCommand,
 	stop: stopRunCommand,
 	logs: logsRunCommand,
+	prune: pruneRunsCommand,
 };
 
 const rootMeta = {

--- a/packages/cli/src/commands/runs.ts
+++ b/packages/cli/src/commands/runs.ts
@@ -78,6 +78,14 @@ export const listRunsCommand = defineCommand({
 	run: ({ args }) => request(args, { type: "list" }),
 });
 
+export const pruneRunsCommand = defineCommand({
+	meta: {
+		name: "prune",
+		description: "Remove stopped and errored runs and their history.",
+	},
+	run: ({ args }) => request(args, { type: "prune" }),
+});
+
 export const statusRunCommand = defineCommand({
 	meta: { name: "status", description: "Show one Plot run." },
 	args: runIdArg,

--- a/packages/session/src/run-ipc.ts
+++ b/packages/session/src/run-ipc.ts
@@ -79,6 +79,12 @@ const handleRequest = async (runRegistry: RunRegistry, request: RunRequest) => {
 			id: request.id,
 			run: await runRegistry.stop(request.id),
 		};
+	if (request.type === "prune")
+		return {
+			type: "prune_result",
+			ok: true,
+			removed: await runRegistry.prune(),
+		};
 	if (request.type === "protocol_request")
 		return {
 			type: "protocol_response",
@@ -260,6 +266,12 @@ export const createRunIpcClient = (
 			if (response.type !== "stop_result")
 				throw new Error(`unexpected IPC response: ${response.type}`);
 			return response.run;
+		},
+		prune: async (): Promise<readonly RunRecord[]> => {
+			const response = await request({ type: "prune" });
+			if (response.type !== "prune_result")
+				throw new Error(`unexpected IPC response: ${response.type}`);
+			return response.removed;
 		},
 		submit: async (
 			id: string,

--- a/packages/session/src/run-registry.ts
+++ b/packages/session/src/run-registry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
-import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { EventHub } from "@plot/common/event-stream";
 import { errorMessage, hasErrnoCode, isRecord } from "@plot/common/primitives";
@@ -92,6 +92,7 @@ export const runRequestSchema = Schema.Union([
 	Schema.Struct({ type: Schema.Literal("list") }),
 	Schema.Struct({ type: Schema.Literal("status"), id: NonEmptyString }),
 	Schema.Struct({ type: Schema.Literal("stop"), id: NonEmptyString }),
+	Schema.Struct({ type: Schema.Literal("prune") }),
 	Schema.Struct({
 		type: Schema.Literal("protocol_stream"),
 		id: NonEmptyString,
@@ -127,6 +128,11 @@ export const runResponseSchema = Schema.Union([
 		run: optional(runRecordSchema),
 	}),
 	Schema.Struct({
+		type: Schema.Literal("prune_result"),
+		ok: Schema.Literal(true),
+		removed: Schema.Array(runRecordSchema),
+	}),
+	Schema.Struct({
 		type: Schema.Literal("protocol_ready"),
 		ok: Schema.Literal(true),
 		run: optional(runRecordSchema),
@@ -159,6 +165,7 @@ export interface RunStore {
 export interface RunRegistryRuntime {
 	readonly spawn: (input?: RunSpawnOptions) => Promise<RunRecord>;
 	readonly stop: (id: string) => Promise<RunRecord | undefined>;
+	readonly prune: () => Promise<readonly RunRecord[]>;
 	readonly list: () => Promise<readonly RunRecord[]>;
 	readonly status: (id: string) => Promise<RunRecord | undefined>;
 	readonly attachRecords: (
@@ -616,5 +623,19 @@ export class RunRegistry implements RunRegistryRuntime {
 
 	async shutdown(): Promise<void> {
 		await Promise.all([...this.live.keys()].map((id) => this.stop(id)));
+	}
+
+	/** Remove ended run records and their Session History; live runs stay. */
+	async prune(): Promise<readonly RunRecord[]> {
+		const removed: RunRecord[] = [];
+		for (const record of await this.options.store.list()) {
+			if (this.live.has(record.id)) continue;
+			if (record.status !== "stopped" && record.status !== "error") continue;
+			await this.options.store.remove(record.id);
+			const history = this.historyPath(record.id);
+			if (history !== undefined) await rm(history, { force: true });
+			removed.push(clone(record));
+		}
+		return removed;
 	}
 }

--- a/packages/session/test/run-registry.test.ts
+++ b/packages/session/test/run-registry.test.ts
@@ -522,3 +522,53 @@ test("runRegistry persists Session History and replays it after stop", async () 
 		empty.push(event);
 	expect(empty).toHaveLength(0);
 });
+
+test("runRegistry prune removes ended records and history, keeps live runs", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "plot-runRegistry-prune-"));
+	const historyDir = join(cwd, "history");
+	const store = createMemoryRunStore();
+	let child: FakeChild | undefined;
+	const runRegistry = new RunRegistry({
+		cli: { command: "bun", args: ["main.ts"] },
+		cwd,
+		store,
+		id: () => "run-live",
+		now: () => "2026-01-01T00:00:00.000Z",
+		historyDir,
+		spawnChild: () => {
+			child = new FakeChild("session-live");
+			queueMicrotask(() =>
+				child?.emit({
+					protocol: "plot.session.v2",
+					kind: "welcome",
+					sessionId: "session-live",
+					limits: {
+						maxInputLineBytes: 1_000,
+						maxOutputLineBytes: 1_000,
+						maxPendingRequests: 4,
+						maxBufferedEvents: 4,
+					},
+				}),
+			);
+			return child;
+		},
+	});
+	await store.upsert({
+		id: "run-dead",
+		status: "stopped",
+		cwd,
+		createdAt: "2026-01-01T00:00:00.000Z",
+	});
+	await mkdir(historyDir, { recursive: true });
+	await writeFile(runHistoryPath(historyDir, "run-dead"), "{}\n");
+	await runRegistry.spawn();
+
+	const removed = await runRegistry.prune();
+
+	expect(removed.map((record) => record.id)).toEqual(["run-dead"]);
+	expect(existsSync(runHistoryPath(historyDir, "run-dead"))).toBe(false);
+	expect((await runRegistry.list()).map((record) => record.id)).toEqual([
+		"run-live",
+	]);
+	await runRegistry.stop("run-live");
+});


### PR DESCRIPTION
## Problem

`RunStore.remove` has existed since the store was written, but **nothing ever calls it** — there is no way to delete a run record. Every stopped or errored run accumulates in `runs.json` forever (a dogfooding registry here reached 16 dead `plot-alpha-pr-review` records), and since durable Session History landed, each dead run also pins a history file on disk.

## Feature

- `RunRegistry.prune()`: removes records with status `stopped`/`error` that are not currently live, deletes their `history/<runId>.jsonl`, and returns the removed records.
- Run IPC verb `prune` (`prune_result`), implemented by both the daemon dispatch and the socket client, so any registry consumer can prune.
- CLI: `plot prune`.

Live runs are never touched; pruning is scoped to ended records only.

## Test

Registry-level behavior test: a stored stopped record with a history file is removed (record + file), while a live spawned run survives the prune.