### PR TITLE
feat(tui): show operator actions in the detail attention section

### DIFF
--- a/packages/tui/src/detail-view.ts
+++ b/packages/tui/src/detail-view.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@plot/common/primitives";
 import { formatDuration, type WorkRowModel } from "./dashboard-model.js";
 import {
 	asLine,
@@ -46,11 +47,21 @@ const workTrailLines = (
 	);
 };
 
+/** Labels of the Source-declared Operator Actions on a blocked Work Item. */
+const operatorActionLabels = (selected: WorkRowModel): readonly string[] =>
+	(selected.work.operatorActions ?? []).flatMap((action) => {
+		if (!isRecord(action)) return [];
+		const label = action["label"] ?? action["id"];
+		return typeof label === "string" ? [label] : [];
+	});
+
 const attentionLines = (selected: WorkRowModel): readonly DashboardLine[] => {
+	const actions = operatorActionLabels(selected);
 	const lines = [
 		...(selected.work.blockedReason === undefined
 			? []
 			: [selected.work.blockedReason]),
+		...(actions.length === 0 ? [] : [`actions: ${actions.join(" · ")}`]),
 		...(selected.status === "failed" ? [quoteActivity(selected.activity)] : []),
 		...(selected.stale ? [`stale · last event ${selected.lastEventAgo}`] : []),
 	];

--- a/packages/tui/test/detail-view-actions.test.ts
+++ b/packages/tui/test/detail-view-actions.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import type { WorkItemProjection } from "@plot/session/projection";
+import type { WorkRowModel } from "../src/dashboard-model.js";
+import { detailBodyLines } from "../src/detail-view.js";
+
+const work: WorkItemProjection = {
+	workKey: "work-1",
+	sourceId: "source-1",
+	title: "Work 1",
+	labels: [],
+	status: "blocked",
+	blockedReason: "needs approval",
+	operatorActions: [
+		{ id: "approve", label: "Approve" },
+		{ id: "skip" },
+		"garbage",
+	],
+};
+
+const row: WorkRowModel = {
+	work,
+	label: "Work 1",
+	status: "blocked",
+	meta: "",
+	activity: "waiting",
+	lastEventAgo: "1s",
+	stale: false,
+	attention: true,
+};
+
+test("attention section lists Source-declared operator actions", () => {
+	const text = detailBodyLines(row, 2000)
+		.map((line) => JSON.stringify(line))
+		.join("\n");
+	expect(text).toContain("needs approval");
+	expect(text).toContain("actions: Approve · skip");
+});


### PR DESCRIPTION
## Problem

When a Work Item is blocked, its Source declares Operator Actions (`work.operatorActions`) — the choices a human can take. The web inspector surfaces them; the TUI showed only `blockedReason`, leaving the operator staring at *why* it is blocked with no hint of *what they can do about it*.

## Feature

The detail view's Attention section now lists the declared action labels next to the blocked reason:

```
Attention
  needs approval
  actions: Approve · Request changes
```

Parsing is defensive (label falls back to id; non-record entries are skipped) since `operatorActions` is `readonly unknown[]` in the projection.

Display-only parity step — taking an action from the TUI (recording the Operator Observation) is follow-up work on the keybinding/control seam.

## Test

`detail-view-actions.test.ts`: blocked row with `[{id, label}, {id}, "garbage"]` renders `actions: Approve · skip` and keeps the blocked reason.