### PR TITLE
feat(cli): human-readable run commands with --json escape hatch

### DIFF
--- a/packages/cli/src/commands/runs.ts
+++ b/packages/cli/src/commands/runs.ts
@@ -11,6 +11,7 @@ import {
 	sendRunIpcRequest,
 } from "@plot/session/run-ipc";
 import type { RunRequest } from "@plot/session/run-registry";
+import { formatRunResponse } from "../run-output.js";
 
 const runIpcOptions = (_args: ParsedArgs): RunIpcOptions => ({
 	cwd: process.cwd(),
@@ -21,17 +22,28 @@ const json = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 const request = async (args: ParsedArgs, value: RunRequest) => {
 	const io = getCliIo();
 	try {
+		const response = await sendRunIpcRequest(runIpcOptions(args), value);
 		await io.writeStdout(
-			json(await sendRunIpcRequest(runIpcOptions(args), value)),
+			args["json"] === true
+				? json(response)
+				: `${formatRunResponse(response)}\n`,
 		);
 	} catch (error) {
 		await writeCliStderr(
 			io,
-			`Error: ${errorMessage(error)}\nFix: run \`plot web\` or \`plot api --http\`.\n`,
+			`Error: ${errorMessage(error)}\nFix: start the daemon with \`plot registry serve\`, \`plot tui\`, or \`plot web\`.\n`,
 		);
 		throw error;
 	}
 };
+
+const jsonFlag = {
+	json: {
+		type: "boolean",
+		description: "Print the raw IPC response as JSON.",
+		default: false,
+	},
+} as const;
 
 const streamEvents = async (args: ParsedArgs) => {
 	const io = getCliIo();
@@ -75,6 +87,7 @@ const runIdArg = {
 
 export const listRunsCommand = defineCommand({
 	meta: { name: "ls", description: "List Plot runs." },
+	args: jsonFlag,
 	run: ({ args }) => request(args, { type: "list" }),
 });
 
@@ -83,18 +96,19 @@ export const pruneRunsCommand = defineCommand({
 		name: "prune",
 		description: "Remove stopped and errored runs and their history.",
 	},
+	args: jsonFlag,
 	run: ({ args }) => request(args, { type: "prune" }),
 });
 
 export const statusRunCommand = defineCommand({
 	meta: { name: "status", description: "Show one Plot run." },
-	args: runIdArg,
+	args: { ...runIdArg, ...jsonFlag },
 	run: ({ args }) => request(args, { type: "status", id: str(args, "runId")! }),
 });
 
 export const stopRunCommand = defineCommand({
 	meta: { name: "stop", description: "Stop one Plot run." },
-	args: runIdArg,
+	args: { ...runIdArg, ...jsonFlag },
 	run: ({ args }) => request(args, { type: "stop", id: str(args, "runId")! }),
 });
 

--- a/packages/cli/src/run-output.ts
+++ b/packages/cli/src/run-output.ts
@@ -1,0 +1,115 @@
+import type { RunRecord, RunResponse } from "@plot/session/run-registry";
+
+const agoOf = (record: RunRecord, nowMs: number): string => {
+	const ms = Date.parse(record.lastSeenAt ?? record.createdAt);
+	if (!Number.isFinite(ms)) return "-";
+	const seconds = Math.max(0, Math.round((nowMs - ms) / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+	if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
+	return `${Math.round(seconds / 86_400)}d`;
+};
+
+const pad = (value: string, width: number): string =>
+	value.length >= width ? value : value + " ".repeat(width - value.length);
+
+const table = (rows: readonly (readonly string[])[]): string => {
+	const widths = rows[0]?.map((_, column) =>
+		Math.max(...rows.map((row) => (row[column] ?? "").length)),
+	);
+	return rows
+		.map((row) =>
+			row
+				.map((cell, column) => pad(cell, widths?.[column] ?? cell.length))
+				.join("  ")
+				.trimEnd(),
+		)
+		.join("\n");
+};
+
+const liveFirst = (runs: readonly RunRecord[]): readonly RunRecord[] =>
+	runs.toSorted((left, right) => {
+		const alive =
+			Number(right.status === "online") - Number(left.status === "online");
+		if (alive !== 0) return alive;
+		return (
+			Date.parse(right.lastSeenAt ?? right.createdAt) -
+			Date.parse(left.lastSeenAt ?? left.createdAt)
+		);
+	});
+
+export const formatRunsTable = (
+	runs: readonly RunRecord[],
+	nowMs = Date.now(),
+): string => {
+	if (runs.length === 0) return "No Plot runs.";
+	const rows = [
+		["ID", "STATUS", "WORKFLOW", "PROJECT", "SEEN", "EVENTS"],
+		...liveFirst(runs).map((record) => [
+			record.id.slice(0, 8),
+			record.status,
+			record.workflowName ?? "-",
+			record.cwdName ?? record.cwd,
+			agoOf(record, nowMs),
+			record.lastSequence === undefined ? "-" : `#${record.lastSequence}`,
+		]),
+	];
+	return table(rows);
+};
+
+const runLine = (record: RunRecord, nowMs: number): string =>
+	`${record.id.slice(0, 8)}  ${record.status}  ${record.workflowName ?? "-"}  ${agoOf(record, nowMs)}`;
+
+export const formatRunStatus = (
+	record: RunRecord | undefined,
+	nowMs = Date.now(),
+): string => {
+	if (record === undefined) return "Run not found.";
+	const fields: readonly (readonly [string, string | undefined])[] = [
+		["id", record.id],
+		["status", record.status],
+		["workflow", record.workflowName],
+		["cwd", record.cwd],
+		["session", record.sessionId],
+		["seen", agoOf(record, nowMs) + " ago"],
+		[
+			"events",
+			record.lastSequence === undefined
+				? undefined
+				: `#${record.lastSequence} (${record.lastEventType ?? "event"})`,
+		],
+		["stderr", record.stderrTail],
+	];
+	return fields
+		.filter(([, value]) => value !== undefined && value !== "")
+		.map(([name, value]) => `${pad(name, 9)}${value}`)
+		.join("\n");
+};
+
+/** Human rendering of run IPC responses; raw JSON stays behind --json. */
+export const formatRunResponse = (
+	response: RunResponse,
+	nowMs = Date.now(),
+): string => {
+	switch (response.type) {
+		case "list_result":
+			return formatRunsTable(response.runs, nowMs);
+		case "status_result":
+			return formatRunStatus(response.run, nowMs);
+		case "stop_result":
+			return response.run === undefined
+				? "Run not found."
+				: `Stopped ${runLine(response.run, nowMs)}`;
+		case "prune_result":
+			return response.removed.length === 0
+				? "Nothing to prune."
+				: [
+						`Removed ${response.removed.length} run(s):`,
+						...response.removed.map((record) => `  ${runLine(record, nowMs)}`),
+					].join("\n");
+		case "error":
+			return `Error: ${response.error}`;
+		default:
+			return JSON.stringify(response, null, 2);
+	}
+};

--- a/packages/cli/test/run-output.test.ts
+++ b/packages/cli/test/run-output.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { formatRunResponse, formatRunsTable } from "../src/run-output.js";
+
+const record = {
+	id: "76e84f20-ca5e-4061-8e66-d8dab84950d4",
+	status: "online",
+	cwd: "/repo/epic",
+	cwdName: "epic",
+	createdAt: "2026-01-01T00:00:00.000Z",
+	lastSeenAt: "2026-01-01T00:00:50.000Z",
+	workflowName: "pr-review",
+	lastSequence: 42,
+} as const;
+
+const nowMs = Date.parse("2026-01-01T00:01:00.000Z");
+
+describe("run output", () => {
+	test("ls renders a table with live runs first", () => {
+		const stopped = {
+			...record,
+			id: "aaaaaaaa-0000-0000-0000-000000000000",
+			status: "stopped",
+		} as const;
+		const text = formatRunsTable([stopped, record], nowMs);
+		expect(text).toContain("ID");
+		expect(text.indexOf("76e84f20")).toBeLessThan(text.indexOf("aaaaaaaa"));
+		expect(text).toContain("pr-review");
+		expect(text).toContain("10s");
+		expect(formatRunsTable([], nowMs)).toBe("No Plot runs.");
+	});
+
+	test("status, stop, prune and error render for humans", () => {
+		expect(
+			formatRunResponse(
+				{ type: "status_result", ok: true, run: record },
+				nowMs,
+			),
+		).toContain("status   online");
+		expect(formatRunResponse({ type: "status_result", ok: true }, nowMs)).toBe(
+			"Run not found.",
+		);
+		expect(
+			formatRunResponse(
+				{ type: "stop_result", ok: true, id: record.id, run: record },
+				nowMs,
+			),
+		).toContain("Stopped 76e84f20");
+		expect(
+			formatRunResponse({ type: "prune_result", ok: true, removed: [] }, nowMs),
+		).toBe("Nothing to prune.");
+		expect(
+			formatRunResponse({ type: "error", ok: false, error: "boom" }, nowMs),
+		).toBe("Error: boom");
+	});
+});


### PR DESCRIPTION
## Problem

`plot ls`, `status`, `stop`, and `prune` printed the raw run-IPC response envelope:

```json
{ "type": "list_result", "ok": true, "runs": [ { "id": "c977b1d2-…", … } ] }
```

Machine output where an operator is standing — a slop seam between the daemon and the person using it.

## Change

```
ID        STATUS   WORKFLOW              PROJECT  SEEN  EVENTS
76e84f20  online   plot-pr-review        epic     10s   #4210
c977b1d2  stopped  plot-alpha-pr-review  epic     2d    #94666
```

- `ls`: table, live runs first, then most recently seen
- `status`: labeled fields, including `stderrTail` when a run died with diagnostics
- `stop` / `prune`: one-line summaries of what actually happened
- `--json` on all four: the raw envelope, unchanged, for scripts
- connection-error hint now says `plot registry serve` / `plot tui` / `plot web` instead of the stale `plot api --http` pairing

## Test

`run-output.test.ts`: table ordering (live first), empty state, status fields, not-found, stop/prune/error renderings — pure formatter, deterministic clock.