### PR TITLE
feat(session): add waiting work status

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -174,6 +174,8 @@ registerTool(({ work }) => defineTool({ name: "load_context", ... }));
 
 ## Operator Actions
 
+Use `status: "waiting"` for parked work waiting on the world; use `status: "blocked"` only when a human choice is needed.
+
 Use `operatorActions` when a Work Item needs a human choice.
 
 ```ts

--- a/examples/pr-review/github-pr-reviewer.extension.ts
+++ b/examples/pr-review/github-pr-reviewer.extension.ts
@@ -971,7 +971,10 @@ export default definePlotExtension<GitHubPrReviewerConfig>({
 							workspace: prWorkspacePath(repo, pr.number),
 							...(eligibility.kind === "hold"
 								? {
-										status: "blocked" as const,
+										status:
+											eligibility.label === "reviewed"
+												? ("waiting" as const)
+												: ("blocked" as const),
 										blockedReason: eligibility.reason,
 									}
 								: {}),

--- a/packages/agent/src/model.ts
+++ b/packages/agent/src/model.ts
@@ -154,6 +154,7 @@ export interface OperatorAction {
 }
 export type WorkStatus =
 	| "pending"
+	| "waiting"
 	| "running"
 	| "blocked"
 	| "draining"

--- a/packages/session/src/extensions/source.ts
+++ b/packages/session/src/extensions/source.ts
@@ -38,6 +38,8 @@ import {
 	discoveredFactKey,
 	isBlocked,
 	isCancelled,
+	isHeld,
+	isWaiting,
 	releasedReason,
 	sourceIdForExtension,
 	templateContextForWork,
@@ -268,7 +270,9 @@ export const makePlotExtensionSourceBundle = (options: {
 						? "draining"
 						: isBlocked(work)
 							? "blocked"
-							: "pending";
+							: isWaiting(work)
+								? "waiting"
+								: "pending";
 				const currentRunId = [...snapshot.running.values()].find((run) => {
 					if (run.sourceId !== source) return false;
 					return (
@@ -320,7 +324,7 @@ export const makePlotExtensionSourceBundle = (options: {
 				snapshot.facts.get(discoveredFactKey(source)),
 			).some(
 				(candidate) =>
-					!isBlocked(candidate) &&
+					!isHeld(candidate) &&
 					workKeyForExtensionWork(options.extension, candidate) ===
 						work.workKey,
 			);
@@ -347,7 +351,7 @@ export const makePlotExtensionSourceBundle = (options: {
 					snapshot.running.has(key) ||
 					heldKeys.has(key) ||
 					claimedIds.has(extensionWork.id) ||
-					isBlocked(extensionWork)
+					isHeld(extensionWork)
 				)
 					return [];
 				selectedWork.set(key, extensionWork);

--- a/packages/session/src/extensions/work.ts
+++ b/packages/session/src/extensions/work.ts
@@ -41,7 +41,9 @@ export const extensionWorkSchema = Schema.Struct({
 	title: optional(Schema.String),
 	url: optional(Schema.String),
 	subject: optional(Schema.String),
-	status: optional(Schema.Literals(["pending", "blocked", "cancelled"])),
+	status: optional(
+		Schema.Literals(["pending", "waiting", "blocked", "cancelled"]),
+	),
 	blockedReason: optional(Schema.String),
 	workspace: optional(NonEmptyString),
 	display: optional(displaySchema),
@@ -147,6 +149,9 @@ export const releasedReason = (source: SourceId) =>
 export const cancelledReason = (source: SourceId) =>
 	`work was cancelled by source ${source}`;
 export const isBlocked = (work: PlotExtensionWork) => work.status === "blocked";
+export const isWaiting = (work: PlotExtensionWork) => work.status === "waiting";
+export const isHeld = (work: PlotExtensionWork) =>
+	isBlocked(work) || isWaiting(work);
 export const isCancelled = (work: PlotExtensionWork) =>
 	work.status === "cancelled";
 export const toSubject = (work: PlotExtensionWork) =>

--- a/packages/session/src/projection-parts/types.ts
+++ b/packages/session/src/projection-parts/types.ts
@@ -24,6 +24,7 @@ export type DashboardStatus =
 	| "error";
 export type WorkStatus =
 	| "pending"
+	| "waiting"
 	| "running"
 	| "blocked"
 	| "draining"

--- a/packages/session/src/run-registry.ts
+++ b/packages/session/src/run-registry.ts
@@ -383,6 +383,27 @@ export const decodeRunRequest = (value: unknown): RunRequest =>
 	decodeBoundary(runRequestSchema, value);
 export const decodeRunResponse = (value: unknown): RunResponse =>
 	decodeBoundary(runResponseSchema, value);
+
+const historySkippedAgentEventTypes = new Set([
+	"thinking_delta",
+	"text_delta",
+	"message_delta",
+	"message_partial",
+	"toolcall_delta",
+]);
+
+const agentEventType = (event: unknown): string | undefined => {
+	if (!isRecord(event)) return undefined;
+	const update = event["assistantMessageEvent"];
+	const nested = isRecord(update) ? update["type"] : undefined;
+	const type = nested ?? event["type"];
+	return typeof type === "string" ? type : undefined;
+};
+
+const shouldWriteHistory = (record: EventServerRecord): boolean =>
+	record.event.kind !== "agent_event" ||
+	!historySkippedAgentEventTypes.has(agentEventType(record.event.event) ?? "");
+
 export class RunRegistry implements RunRegistryRuntime {
 	private readonly live = new Map<string, LiveRun>();
 	private readonly options: Required<
@@ -458,12 +479,13 @@ export class RunRegistry implements RunRegistryRuntime {
 			: runHistoryPath(this.options.historyDir, id);
 	}
 
-	// ponytail: history grows unboundedly per run; add rotation when a
-	// long-lived session actually hurts (files observed so far are <1MB).
+	// ponytail: history still grows unboundedly per run; add snapshot rotation when
+	// compacted files actually hurt.
 	private async appendHistory(
 		live: LiveRun,
 		record: EventServerRecord,
 	): Promise<void> {
+		if (!shouldWriteHistory(record)) return;
 		const path = this.historyPath(live.record.id);
 		if (path === undefined) return;
 		if (live.history === undefined) {

--- a/packages/session/src/sdk.ts
+++ b/packages/session/src/sdk.ts
@@ -75,7 +75,11 @@ export interface OperatorAction {
 	readonly confirm?: OperatorActionConfirm;
 }
 
-export type PlotExtensionWorkStatus = "pending" | "blocked" | "cancelled";
+export type PlotExtensionWorkStatus =
+	| "pending"
+	| "waiting"
+	| "blocked"
+	| "cancelled";
 
 export interface PlotExtensionWork {
 	/** Stable domain identity, e.g. github:acme/web:pr:42 or jira:EPIC-123. */
@@ -91,13 +95,15 @@ export interface PlotExtensionWork {
 	/**
 	 * Source-visible scheduling state. Defaults to pending.
 	 *
-	 * Blocked work keeps its claim and stays visible, but is not dispatched and
-	 * running attempts are not interrupted. Cancelled work is interrupted and
-	 * released immediately. Omitting the work from discovery drains it: an active
+	 * Waiting and blocked work keep their claim and stay visible, but are not
+	 * dispatched and running attempts are not interrupted. Waiting means the
+	 * world must move; blocked means a human should act. Cancelled work is
+	 * interrupted and released immediately. Omitting the work from discovery drains it: an active
 	 * run finishes its current turn without continuation, then the claim is
 	 * released without redispatch.
 	 */
 	readonly status?: PlotExtensionWorkStatus;
+	/** Why held work is waiting or blocked. */
 	readonly blockedReason?: string;
 	/**
 	 * Absolute per-work workspace directory. Plot creates the directory before

--- a/packages/session/test/extension-source.test.ts
+++ b/packages/session/test/extension-source.test.ts
@@ -131,6 +131,49 @@ describe("extension source adapter", () => {
 		expect(result.diagnostics[0]?.message).toContain("id");
 	});
 
+	test("waiting work stays visible without dispatch", async () => {
+		let runs = 0;
+		const bundle = makePlotExtensionSourceBundle({
+			workflow,
+			paths,
+			config: undefined,
+			extension: { id: "waiting", create: () => ({ discover: () => [] }) },
+			runtime: {
+				discover: () => [
+					{
+						id: "work:1",
+						version: "v1",
+						status: "waiting" as const,
+						blockedReason: "reviewed at this head",
+					},
+				],
+			},
+		});
+		const agent = makePlotAgentLayer({
+			sources: [bundle.source],
+			runner: {
+				run: () => {
+					runs++;
+					return {};
+				},
+			},
+		});
+
+		const first = await agent.tickOnce();
+		const second = await agent.tickOnce();
+		const snapshot = await agent.snapshot();
+
+		expect(first.started).toHaveLength(0);
+		expect(second.started).toHaveLength(0);
+		expect(runs).toBe(0);
+		expect(
+			snapshot.work.get(workKey("extension:waiting:work:1:v1")),
+		).toMatchObject({
+			status: "waiting",
+			blockedReason: "reviewed at this head",
+		});
+	});
+
 	test("superseded versions drain; blocked work holds claim without redispatch", async () => {
 		let version = "sha-1";
 		let blocked = false;

--- a/packages/session/test/run-registry.test.ts
+++ b/packages/session/test/run-registry.test.ts
@@ -499,6 +499,30 @@ test("runRegistry persists Session History and replays it after stop", async () 
 			type: "session_started",
 		},
 	});
+	child?.emit({
+		protocol: "plot.session.v2",
+		kind: "event",
+		sequence: 2,
+		event: {
+			kind: "agent_event",
+			sessionId: "session-history",
+			sequence: 2,
+			timestamp: "2026-01-01T00:00:02.000Z",
+			event: { type: "message_delta", delta: "streaming prose" },
+		},
+	});
+	child?.emit({
+		protocol: "plot.session.v2",
+		kind: "event",
+		sequence: 3,
+		event: {
+			kind: "agent_event",
+			sessionId: "session-history",
+			sequence: 3,
+			timestamp: "2026-01-01T00:00:03.000Z",
+			event: { type: "message_end" },
+		},
+	});
 	await new Promise((resolve) => setTimeout(resolve, 10));
 	await runRegistry.stop(spawned.id);
 
@@ -507,11 +531,19 @@ test("runRegistry persists Session History and replays it after stop", async () 
 		runHistoryPath(historyDir, spawned.id),
 	))
 		replayed.push(event);
-	expect(replayed).toHaveLength(1);
+	expect(replayed).toHaveLength(2);
+	expect(
+		replayed.map((event) => (event as { sequence?: number }).sequence),
+	).toEqual([1, 3]);
 	expect(replayed[0]).toMatchObject({
 		kind: "session_event",
 		type: "session_started",
 		sequence: 1,
+	});
+	expect(replayed[1]).toMatchObject({
+		kind: "agent_event",
+		event: { type: "message_end" },
+		sequence: 3,
 	});
 
 	// A run that never wrote history replays to nothing.

--- a/packages/tui/src/dashboard-model.ts
+++ b/packages/tui/src/dashboard-model.ts
@@ -129,7 +129,10 @@ const displayActivity = (
 	work: WorkItemProjection,
 	attempt: AgentAttemptProjection | undefined,
 ) => {
-	if (work.status === "blocked" && work.blockedReason)
+	if (
+		(work.status === "blocked" || work.status === "waiting") &&
+		work.blockedReason
+	)
 		return work.blockedReason;
 	if (!attempt) return work.status;
 	return (

--- a/packages/tui/src/detail-view.ts
+++ b/packages/tui/src/detail-view.ts
@@ -58,11 +58,12 @@ const operatorActionLabels = (selected: WorkRowModel): readonly string[] =>
 	});
 
 const attentionLines = (selected: WorkRowModel): readonly DashboardLine[] => {
-	const actions = operatorActionLabels(selected);
+	const blocked = selected.status === "blocked";
+	const actions = blocked ? operatorActionLabels(selected) : [];
 	const lines = [
-		...(selected.work.blockedReason === undefined
-			? []
-			: [selected.work.blockedReason]),
+		...(blocked && selected.work.blockedReason !== undefined
+			? [selected.work.blockedReason]
+			: []),
 		...(actions.length === 0 ? [] : [`actions: ${actions.join(" · ")}`]),
 		...(selected.status === "failed" ? [quoteActivity(selected.activity)] : []),
 		...(selected.stale ? [`stale · last event ${selected.lastEventAgo}`] : []),

--- a/packages/tui/src/style.ts
+++ b/packages/tui/src/style.ts
@@ -153,6 +153,7 @@ export const style = {
 	},
 	stage: {
 		pending: fg("muted"),
+		waiting: fg("muted"),
 		running: fg("success"),
 		blocked: compose(fg("error"), bold),
 		draining: fg("warning"),

--- a/packages/tui/test/detail-view-actions.test.ts
+++ b/packages/tui/test/detail-view-actions.test.ts
@@ -35,3 +35,26 @@ test("attention section lists Source-declared operator actions", () => {
 	expect(text).toContain("needs approval");
 	expect(text).toContain("actions: Approve · skip");
 });
+
+test("waiting work does not render as attention", () => {
+	const text = detailBodyLines(
+		{
+			...row,
+			work: {
+				...work,
+				status: "waiting",
+				blockedReason: "reviewed at this head",
+				operatorActions: [{ id: "review-again", label: "Review again" }],
+			},
+			status: "waiting",
+			activity: "idle",
+			attention: false,
+		},
+		2000,
+	)
+		.map((line) => JSON.stringify(line))
+		.join("\n");
+	expect(text).not.toContain("Attention");
+	expect(text).not.toContain("reviewed at this head");
+	expect(text).not.toContain("Review again");
+});

--- a/packages/tui/test/projection.test.ts
+++ b/packages/tui/test/projection.test.ts
@@ -79,6 +79,43 @@ describe("Plot TUI projection", () => {
 		expect(p.attempts.has("run-1")).toBe(true);
 	});
 
+	test("waiting work is visible but not attention", () => {
+		const p = {
+			...emptyProjection("default", "workflow"),
+			work: new Map([
+				[
+					"waiting",
+					{
+						workKey: "waiting",
+						sourceId: "source",
+						title: "Reviewed PR",
+						labels: [],
+						status: "waiting" as const,
+						blockedReason: "reviewed at this head",
+					},
+				],
+				[
+					"blocked",
+					{
+						workKey: "blocked",
+						sourceId: "source",
+						title: "Needs approval",
+						labels: [],
+						status: "blocked" as const,
+						blockedReason: "needs approval",
+					},
+				],
+			]),
+		};
+
+		const model = dashboardModelFrom(p);
+
+		expect(model.work.find((w) => w.work.workKey === "waiting")?.activity).toBe(
+			"reviewed at this head",
+		);
+		expect(model.attention.map((item) => item.workKey)).toEqual(["blocked"]);
+	});
+
 	test("accepts protocol event records", () => {
 		let p = emptyProjection("default", "workflow");
 		p = reduceRecord(

--- a/packages/web/src/inspector.tsx
+++ b/packages/web/src/inspector.tsx
@@ -265,10 +265,22 @@ function OperatorZone({
 			setPendingId(undefined);
 		}
 	};
+	const blocked = work.status === "blocked";
 	return (
-		<Section title="Needs you" tone="attention">
+		<Section
+			title={blocked ? "Needs you" : "Waiting"}
+			tone={blocked ? "attention" : undefined}
+		>
 			{work.blockedReason !== undefined && (
-				<p className="text-xs text-warning-foreground">{work.blockedReason}</p>
+				<p
+					className={
+						blocked
+							? "text-xs text-warning-foreground"
+							: "text-xs text-muted-foreground"
+					}
+				>
+					{work.blockedReason}
+				</p>
 			)}
 			{sent !== undefined ? (
 				<p className="text-xs text-muted-foreground">
@@ -341,7 +353,7 @@ export function Inspector({
 		return null;
 	}
 
-	const blocked = work?.status === "blocked";
+	const held = work?.status === "blocked" || work?.status === "waiting";
 
 	const elapsedMs =
 		current?.startedAtMs === undefined
@@ -407,7 +419,7 @@ export function Inspector({
 			</header>
 			<ScrollArea className="min-h-0 flex-1">
 				<div>
-					{blocked && work !== undefined && (
+					{held && work !== undefined && (
 						<OperatorZone onAction={onAction} work={work} />
 					)}
 					{current !== undefined && (

--- a/packages/web/src/lanes.ts
+++ b/packages/web/src/lanes.ts
@@ -31,6 +31,7 @@ export interface Lanes {
 export const laneOf = (status: WorkStatus): LaneId => {
 	switch (status) {
 		case "pending":
+		case "waiting":
 			return "incoming";
 		case "running":
 		case "draining":

--- a/packages/web/src/work-card.tsx
+++ b/packages/web/src/work-card.tsx
@@ -176,11 +176,24 @@ function Activity() {
 	);
 }
 
-function BlockedReason() {
+function HeldReason() {
 	const { work } = useWorkItem();
 	if (work.blockedReason === undefined) return null;
+	const waiting = work.status === "waiting";
 	return (
-		<p className="text-xs text-warning-foreground">{work.blockedReason}</p>
+		<p
+			className={cn(
+				"text-xs",
+				waiting ? "text-muted-foreground" : "text-warning-foreground",
+			)}
+		>
+			{waiting && (
+				<Badge size="sm" variant="secondary" className="mr-1">
+					waiting
+				</Badge>
+			)}
+			{work.blockedReason}
+		</p>
 	);
 }
 
@@ -246,7 +259,7 @@ const WorkCard = {
 	Header,
 	Subtitle,
 	Activity,
-	BlockedReason,
+	HeldReason,
 	OperatorActions,
 	Meta,
 };
@@ -262,6 +275,8 @@ export function IncomingCard({ item, selected }: WorkCardProps) {
 		<WorkCard.Frame item={item} selected={selected}>
 			<WorkCard.Header />
 			<WorkCard.Subtitle />
+			<WorkCard.HeldReason />
+			{item.work.status === "waiting" && <WorkCard.OperatorActions />}
 			<WorkCard.Meta />
 		</WorkCard.Frame>
 	);
@@ -289,7 +304,7 @@ export function NeedsYouCard({ item, selected }: WorkCardProps) {
 		>
 			<WorkCard.Header />
 			<WorkCard.Subtitle />
-			<WorkCard.BlockedReason />
+			<WorkCard.HeldReason />
 			<WorkCard.OperatorActions />
 			<WorkCard.Meta />
 		</WorkCard.Frame>

--- a/packages/web/test/inspector.test.tsx
+++ b/packages/web/test/inspector.test.tsx
@@ -80,6 +80,31 @@ test("inspector renders operator zone, live run, timeline, and history", () => {
 	expect(html).not.toContain("/tmp/transcript.jsonl");
 });
 
+test("inspector renders waiting work without attention copy", () => {
+	const waiting = projection();
+	const html = renderToString(
+		<Inspector
+			onAction={async () => true}
+			sessionRunId="run-web-1"
+			onClose={() => undefined}
+			projection={{
+				...waiting,
+				work: {
+					"work-1": {
+						...waiting.work["work-1"]!,
+						status: "waiting",
+						blockedReason: "reviewed at this head",
+					},
+				},
+			}}
+			workKey="work-1"
+		/>,
+	);
+	expect(html).toContain("Waiting");
+	expect(html).toContain("reviewed at this head");
+	expect(html).not.toContain("Needs you");
+});
+
 test("inspector offers the transcript once the attempt settles", () => {
 	const settled = projection();
 	const html = renderToString(

--- a/packages/web/test/lanes.test.ts
+++ b/packages/web/test/lanes.test.ts
@@ -79,6 +79,7 @@ describe("lanes", () => {
 			projection({
 				work: [
 					work("a", "pending"),
+					work("w", "waiting"),
 					work("b", "running", "run-b"),
 					work("c", "blocked"),
 					work("d", "done"),
@@ -88,7 +89,7 @@ describe("lanes", () => {
 				completed: [completed("d")],
 			}),
 		);
-		expect(lanes.incoming.map((item) => item.work.workKey)).toEqual(["a"]);
+		expect(lanes.incoming.map((item) => item.work.workKey)).toEqual(["a", "w"]);
 		expect(lanes.acting[0]?.attempt?.runId).toBe("run-b");
 		expect(lanes.needsYou.map((item) => item.work.workKey)).toEqual(["c"]);
 		// "d" appears once (completed record wins); "e" has no completed record.


### PR DESCRIPTION
## Summary
- add a waiting Work Item status for parked/non-attention work
- map waiting through session projection, web lanes, and TUI attention
- stop writing transient agent delta events to durable Session History
- update pr-review to park reviewed-at-head PRs as waiting

## Tests
- bun run check