### PR TITLE
Simplify CLI agent-end rendering

### DIFF
--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -64,42 +64,26 @@ export const renderAuthStatus = (statuses: readonly AuthStatusInfo[]) =>
 				]),
 			])}\n`;
 
-const textFromContent = (content: unknown): string =>
-	typeof content === "string"
-		? content
-		: Array.isArray(content)
-			? content
-					.flatMap((b) =>
-						isRecord(b) && b["type"] === "text" && typeof b["text"] === "string"
-							? [b["text"]]
-							: [],
-					)
-					.join("\n")
-			: "";
-
-const collectTextBlocks = (value: unknown): readonly string[] => {
-	if (isRecord(value)) {
-		if (value["type"] === "text" && typeof value["text"] === "string")
-			return [value["text"]];
-		return Object.values(value).flatMap(collectTextBlocks);
-	}
-	return Array.isArray(value) ? value.flatMap(collectTextBlocks) : [];
-};
-
 const finalAssistantTextFromAgentEnd = (event: unknown): string | undefined => {
-	if (!isRecord(event)) return undefined;
-	if (!Array.isArray(event["messages"])) {
-		const fallback = collectTextBlocks(event).join("\n").trim();
-		return fallback.length ? fallback : undefined;
-	}
+	if (!isRecord(event) || !Array.isArray(event["messages"])) return undefined;
 	const assistant = event["messages"].findLast(
 		(m) => isRecord(m) && m["role"] === "assistant",
 	);
 	if (!isRecord(assistant)) return undefined;
-	const text = textFromContent(assistant["content"]).trim();
-	if (text.length) return text;
-	const fallback = collectTextBlocks(assistant).join("\n").trim();
-	return fallback.length ? fallback : undefined;
+	const content = assistant["content"];
+	if (typeof content === "string") return content.trim() || undefined;
+	if (!Array.isArray(content)) return undefined;
+	const text = content
+		.flatMap((block) =>
+			isRecord(block) &&
+			block["type"] === "text" &&
+			typeof block["text"] === "string"
+				? [block["text"]]
+				: [],
+		)
+		.join("\n")
+		.trim();
+	return text.length ? text : undefined;
 };
 
 export const renderRunEvent = (record: RuntimeEvent): string | undefined => {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runPlotCli } from "../src/cli.js";
 import { selectOptionId } from "../src/commands/auth.js";
-import { renderModels } from "../src/render.js";
+import { renderModels, renderRunEvent } from "../src/render.js";
 import {
 	flushRawStdout,
 	restoreStdout,
@@ -401,6 +401,21 @@ describe("plot CLI", () => {
 		expect(output).toContain("plot-ai/sdk");
 		expect(output).toContain("definePlotExtension");
 		expect(output).toContain("Do not import Plot internals");
+	});
+
+	test("run output renders only the last assistant message content", () => {
+		expect(
+			renderRunEvent({
+				kind: "agent_event",
+				event: {
+					type: "agent_end",
+					messages: [
+						{ role: "assistant", content: "old" },
+						{ role: "assistant", content: [{ type: "text", text: "done" }] },
+					],
+				},
+			} as never),
+		).toBe("\nFinal assistant message:\ndone\n\nInner agent finished.\n");
 	});
 
 	test("serves session protocol over API stdio with telemetry on stderr", async () => {


### PR DESCRIPTION
## Summary
- simplify CLI rendering of agent_end events to only inspect the explicit last assistant message
- remove the recursive arbitrary payload text scan fallback
- add focused coverage for rendering the last assistant message content

## Audit note
This targets over-clever complexity in @plot/cli: the previous fallback recursively walked the entire agent_end event/assistant payload looking for any text block. That guessed across protocol internals instead of rendering the one shape the CLI owns: the final assistant message content.

Net line delta: 31 insertions, 32 deletions.

## Test plan
- bun --filter @plot/cli test
- bun run check