### PR TITLE
fix(tui): make session shutdown the safe default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ plot check WORKFLOW.md
 plot WORKFLOW.md
 ```
 
-`plot WORKFLOW.md` starts or attaches to its Session and opens the terminal dashboard. Leaving the dashboard detaches; the Session keeps running.
+`plot WORKFLOW.md` starts or attaches to its Session and opens the terminal dashboard. `q` or Ctrl-C confirms before stopping; `d` explicitly detaches and leaves the Session running.
 
 ```bash
 plot start WORKFLOW.md    # start without attaching

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,7 +25,7 @@ The Workflow defaults to `WORKFLOW.md` in the current directory.
 
 Plot canonicalizes the Workflow file path and starts or gets its Active Plot Session. Equivalent paths to the same file attach to the same Session.
 
-The terminal dashboard reconstructs its projection from durable Session History and follows live events. Exiting with `q`, Ctrl-C, or terminal loss only detaches.
+The terminal dashboard reconstructs its projection from durable Session History and follows live events. `q` or Ctrl-C asks for confirmation before stopping. `d` explicitly detaches; terminal loss cannot be treated as a confirmed stop, so the durable Session remains active.
 
 ### `plot start [workflow]`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ plot check WORKFLOW.md
 plot WORKFLOW.md
 ```
 
-Leaving the TUI detaches. Stop explicitly with `plot stop WORKFLOW.md`.
+`q` or Ctrl-C confirms before stopping the Session. Use `d` to explicitly detach and leave it running.
 
 ## Documentation map
 

--- a/docs/nuclear-refactor.md
+++ b/docs/nuclear-refactor.md
@@ -114,9 +114,10 @@ Advanced implementation tuning is not part of root help. Runtime capacities and 
 2. Ask the Session Manager to start-or-get its Session.
 3. Attach the terminal dashboard.
 4. Replay enough durable Session History to construct the current projection, then follow live events without a gap.
-5. On `q`, Ctrl-C, terminal loss, or UI failure, detach only.
+5. On `q` or Ctrl-C, request explicit stop confirmation; confirm stops the Session.
+6. On `d`, terminal loss, or UI failure, detach only. An explicit detach warns that token use may continue and prints the exact stop command.
 
-The command must never stop a Session merely because the TUI exits.
+The command must never stop a Session without confirmed operator intent.
 
 If readiness requires an Operator Action, open the dashboard with the Source in `Needs You`; do not instruct users to run a separate setup command. If the Workflow cannot load at all, or no usable model/auth configuration exists, fail before reserving the Workflow key and print one actionable diagnostic.
 
@@ -519,12 +520,12 @@ Exit condition: runtime code outside the Agent Run domain does not use bare `run
 ### Slice 3: change dashboard ownership
 
 1. Make root `plot [workflow]` start-or-get and attach.
-2. Make TUI exit detach without stopping.
+2. Make TUI stop the safe confirmed default while retaining an explicit detach action.
 3. Add `plot start` and `plot stop` by Workflow.
 4. Move durable replay plus live continuation behind the Session Manager.
 5. Remove protocol envelopes from TUI projection input.
 
-Exit condition: a Session survives TUI exit and the next root invocation reconstructs and attaches to it.
+Exit condition: an explicitly detached Session survives TUI exit and the next root invocation reconstructs and attaches to it.
 
 ### Slice 4: separate Fleet Web Console
 
@@ -577,7 +578,7 @@ Required tests:
 2. Two concurrent starts for one Workflow produce one active Session.
 3. Two Workflows using the same Extension can run concurrently with separate configuration.
 4. Editing a running Workflow does not hot-reload its Session; restarting loads the new definition.
-5. TUI exit leaves the Session online.
+5. Explicit TUI detach leaves the Session online; confirmed TUI stop terminates it.
 6. Reattaching reconstructs projection from history and follows live events without loss or duplication.
 7. `plot start` is idempotent.
 8. `plot stop` is idempotent and releases the Workflow key.
@@ -640,7 +641,7 @@ The final smoke test must prove:
 ```bash
 plot check workflows/acme.md
 plot start workflows/acme.md
-plot workflows/acme.md       # attach, then detach
+plot workflows/acme.md       # attach, then explicitly detach with d
 plot workflows/acme.md       # reconstruct and reattach
 plot web                     # Session is visible
 plot stop workflows/acme.md
@@ -655,6 +656,6 @@ This refactor is done when a new user only needs to understand:
 1. an Extension implements reusable integration behavior;
 2. a Workflow configures that Extension and teaches agent judgment;
 3. Plot keeps one active Session for that Workflow;
-4. `plot` attaches, `plot start` detaches, `plot stop` stops, and `plot web` shows the fleet.
+4. `plot` attaches with safe stop and explicit detach controls, `plot start` starts in the background, `plot stop` stops, and `plot web` shows the fleet.
 
 Users do not need to understand run registries, protocol records, event sequence cursors, daemon commands, one-shot scheduler modes, process IDs, or raw Session IDs. Those concepts either disappear or remain local to the implementation that owns them.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,9 +79,9 @@ plot WORKFLOW.md
 
 The first command validates the Workflow, loads the Extension, checks Source requirements, and validates model/auth readiness without discovery. The second starts or attaches to the Workflow's durable Session.
 
-## Detach and reattach
+## Stop, or explicitly detach
 
-Press `q` in the terminal dashboard. The Session continues in the background.
+Press `q` or Ctrl-C and confirm to stop the Session. Press `d` when you deliberately want it to continue in the background; Plot prints the exact stop command before returning to the shell.
 
 ```bash
 plot WORKFLOW.md         # reconstruct and reattach

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -11,10 +11,13 @@ The terminal dashboard is an attached operator view of one durable Plot Session.
 - If the Workflow has no Active Plot Session, Plot starts one.
 - Otherwise Plot attaches to the existing Session.
 - Durable Session History reconstructs the current projection before live continuation.
-- `q` and Ctrl-C detach; they do not stop the Session.
-- `plot stop WORKFLOW.md` is the explicit shutdown path.
+- `q` or Ctrl-C opens a stop confirmation. `Enter`, `q`, `y`, or Ctrl-C again confirms.
+- `d` explicitly detaches and leaves the Session running. Plot prints a copyable `plot stop` command and warns that token use may continue.
+- `Esc` or `n` cancels the stop confirmation.
+- Terminal loss cannot express confirmed intent, so the durable Session remains active.
+- `plot stop WORKFLOW.md` and the Web Console Stop action remain reliable shutdown paths.
 
-This ownership rule allows a Workflow to continue discovering and handling Work Items while no dashboard is connected.
+This ownership rule allows intentional background operation without making continued token use the easy default.
 
 ## Views
 
@@ -26,13 +29,14 @@ Source requirements that need human work appear as `Needs You`. Their actions ru
 
 The dashboard displays its current key map in the footer. Core controls include:
 
-- `q` — detach
+- `q` or Ctrl-C — confirm and stop
+- `d` — explicitly detach
 - `t` — request a reconciliation tick
-- `d` — toggle debug projection details
+- `b` — toggle debug projection details
 - `c` — toggle runtime configuration
 - arrow keys or `j`/`k` — move selection
 - `Enter` — inspect selected work
 - `s` — invoke an available Source setup action
-- `Esc` — return to the Process Table
+- `Esc` — return to the Process Table or cancel stop confirmation
 
 The TUI consumes Plot concepts and direct RuntimeEvents through the internal Session Manager. It does not own child process lifecycle or expose transport records.

--- a/packages/npm/plot-ai/README.md
+++ b/packages/npm/plot-ai/README.md
@@ -9,7 +9,7 @@ plot check WORKFLOW.md
 plot WORKFLOW.md
 ```
 
-`plot WORKFLOW.md` starts or attaches to the Workflow's Active Plot Session. Leaving the terminal dashboard detaches; use `plot stop WORKFLOW.md` for explicit shutdown and `plot web` for the Fleet Web Console.
+`plot WORKFLOW.md` starts or attaches to the Workflow's Active Plot Session. `q` or Ctrl-C confirms before stopping; `d` explicitly detaches. Use `plot stop WORKFLOW.md` from another shell and `plot web` for the Fleet Web Console.
 
 Extensions import only the public SDK:
 

--- a/packages/tui/src/config-view.ts
+++ b/packages/tui/src/config-view.ts
@@ -35,7 +35,7 @@ export const configViewLines = (
 			? [emptyItem(style.muted)]
 			: r.skillPaths.map((skill) => item(skill))),
 		footer(
-			"j/k scroll · esc back · c close · t tick · g refresh · q quit",
+			"j/k scroll · esc back · c close · t tick · g refresh · d detach · q stop",
 			style.muted,
 		),
 	];

--- a/packages/tui/src/dashboard.ts
+++ b/packages/tui/src/dashboard.ts
@@ -4,6 +4,7 @@ import { dashboardModelFrom, type DashboardModel } from "./dashboard-model.js";
 import {
 	renderLines,
 	asLine,
+	footer,
 	type DashboardLine,
 	maxScroll,
 } from "./dashboard-render.js";
@@ -17,7 +18,8 @@ export interface DashboardActions {
 	readonly tick: () => void;
 	readonly refresh: () => void;
 	readonly toggleDebug: () => void;
-	readonly quit: () => void;
+	readonly stop: () => void;
+	readonly detach: () => void;
 	readonly sourceAction?: (input: {
 		readonly sourceId: string;
 		readonly requirementId: string;
@@ -69,6 +71,7 @@ export class PlotDashboard implements Component {
 	private selectedIndex = 0;
 	private scrollOffset = 0;
 	private showHelp = false;
+	private confirmingStop = false;
 	private liveRenderTimer: ReturnType<typeof setInterval> | undefined;
 	private liveRenderIntervalMs: number | undefined;
 	private liveUpdatesActive = false;
@@ -100,22 +103,42 @@ export class PlotDashboard implements Component {
 
 	handleInput(data: string): void {
 		const key = parseKey(data);
-		if (matchesKey(data, "ctrl+c")) {
-			this.actions.quit();
+		const ctrlC = matchesKey(data, "ctrl+c");
+		if (this.confirmingStop) {
+			if (
+				ctrlC ||
+				key === "q" ||
+				key === "enter" ||
+				key === "return" ||
+				key === "y"
+			) {
+				this.confirmingStop = false;
+				this.actions.stop();
+			} else if (key === "d") this.actions.detach();
+			else if (key === "escape" || key === "esc" || key === "n") {
+				this.confirmingStop = false;
+				this.actions.requestRender?.();
+			}
+			return;
+		}
+		if (ctrlC || key === "q") {
+			this.confirmingStop = true;
+			this.showHelp = false;
+			this.actions.requestRender?.();
 			return;
 		}
 		if ((key === "escape" || key === "esc") && this.showHelp) {
 			this.showHelp = false;
 			return;
 		}
-		if (key === "q") this.actions.quit();
+		if (key === "d") this.actions.detach();
 		else if (key === "?") this.showHelp = !this.showHelp;
 		else if (key === "t") this.actions.tick();
 		else if (key === "g") this.actions.refresh();
 		else if (key === "o") this.openSelectedUrl();
 		else if (key === "s") this.runSourceAction();
 		else if (key === "x") this.cancelSourceAction();
-		else if (key === "d") {
+		else if (key === "b") {
 			this.actions.toggleDebug();
 			this.changeMode(this.mode === "debug" ? "process-table" : "debug");
 		} else if (key === "c")
@@ -168,7 +191,16 @@ export class PlotDashboard implements Component {
 								maxRows: Math.max(1, (this.actions.height?.() ?? 24) - 1),
 								...this.processTableFooter(),
 							});
-		return ["", ...renderLines(lines, width, style.row.selected)];
+		const visibleLines = this.confirmingStop
+			? [
+					...lines.slice(0, -1),
+					footer(
+						`Stop ${this.projection.workflowName}? enter/q yes · d detach instead · esc cancel`,
+						style.warn,
+					),
+				]
+			: lines;
+		return ["", ...renderLines(visibleLines, width, style.row.selected)];
 	}
 
 	private processTableFooter(): {
@@ -178,9 +210,9 @@ export class PlotDashboard implements Component {
 		if (this.showHelp)
 			return {
 				footerText:
-					"↑↓ select · enter details · o open · s setup · x cancel · t tick · c config · d debug · ? hide · q quit",
+					"↑↓ select · enter details · o open · s setup · x cancel · t tick · c config · b debug · d detach · q stop · ? hide",
 			};
-		return { footerText: "? help · q quit" };
+		return { footerText: "? help · d detach · q stop" };
 	}
 
 	private runSourceAction(): void {

--- a/packages/tui/src/debug-view.ts
+++ b/packages/tui/src/debug-view.ts
@@ -21,5 +21,5 @@ export const debugViewLines = (input: {
 		: input.projection.debugEvents
 				.slice(input.scrollOffset, input.scrollOffset + input.viewportRows)
 				.map((entry) => item(entry))),
-	footer("j/k scroll · esc back · d close · q quit", style.muted),
+	footer("j/k scroll · esc back · b close · d detach · q stop", style.muted),
 ];

--- a/packages/tui/src/detail-view.ts
+++ b/packages/tui/src/detail-view.ts
@@ -110,7 +110,7 @@ export const detailViewLines = (input: {
 		asLine(`${style.border("╭─ ")}${style.brand(input.selected.label)}`),
 		...body.slice(input.scrollOffset, input.scrollOffset + input.viewportRows),
 		footer(
-			`j/k scroll · ${input.selected.work.url === undefined ? "" : "o open · "}esc back · q quit`,
+			`j/k scroll · ${input.selected.work.url === undefined ? "" : "o open · "}esc back · d detach · q stop`,
 			style.muted,
 		),
 	];

--- a/packages/tui/src/plot-tui.ts
+++ b/packages/tui/src/plot-tui.ts
@@ -25,11 +25,17 @@ const initialProjection = (session: SessionSummary): DashboardProjection =>
 		skillPaths: [],
 	});
 
+const shellArgument = (value: string): string =>
+	process.platform === "win32"
+		? JSON.stringify(value)
+		: `'${value.replaceAll("'", `'\\''`)}'`;
+
 export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 	let projection = initialProjection(options.session);
-	let resolveDetached!: () => void;
-	const detached = new Promise<void>((resolve) => {
-		resolveDetached = resolve;
+	let exitReason: "detached" | "stopped" | undefined;
+	let resolveExit!: () => void;
+	const exited = new Promise<void>((resolve) => {
+		resolveExit = resolve;
 	});
 	const terminal = options.terminal ?? new ProcessTerminal();
 	const tui = new TUI(terminal);
@@ -66,12 +72,33 @@ export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 			fail(error);
 		}
 	};
-	let detaching = false;
-	const detach = () => {
-		if (detaching) return;
-		detaching = true;
-		resolveDetached();
+	const finish = (reason: "detached" | "stopped") => {
+		if (exitReason !== undefined) return;
+		exitReason = reason;
+		resolveExit();
 		tui.stop();
+	};
+	let stopping = false;
+	const detach = () => {
+		if (stopping) return;
+		finish("detached");
+	};
+	let stopPromise: Promise<void> | undefined;
+	const stop = () => {
+		if (stopping || exitReason !== undefined) return;
+		stopping = true;
+		setStatus("shutting_down");
+		stopPromise = options.manager
+			.stopSession(options.session.id)
+			.then((session) => {
+				if (session === undefined) throw new Error("Session not found");
+				finish("stopped");
+				return undefined;
+			})
+			.catch((error: unknown) => {
+				stopping = false;
+				fail(error);
+			});
 	};
 	const dashboard = new PlotDashboard(projection, {
 		tick: () => {
@@ -79,7 +106,8 @@ export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 		},
 		refresh,
 		toggleDebug: render,
-		quit: detach,
+		stop,
+		detach,
 		sourceAction: (input) => {
 			void options.manager
 				.startSourceAction(options.session.id, input)
@@ -128,16 +156,17 @@ export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 	})().catch((error) => {
 		if (!eventsStopped) fail(error);
 	});
-	process.once("SIGINT", detach);
+	const confirmStop = () => dashboard.handleInput("\u0003");
+	process.on("SIGINT", confirmStop);
 	process.once("SIGTERM", detach);
 	try {
 		dashboard.startLiveUpdates();
 		tui.start();
 		setStatus("running");
 		render();
-		await detached;
+		await exited;
 	} finally {
-		process.off("SIGINT", detach);
+		process.off("SIGINT", confirmStop);
 		process.off("SIGTERM", detach);
 		eventsStopped = true;
 		eventController.abort();
@@ -145,5 +174,12 @@ export const runPlotTui = async (options: PlotTuiOptions): Promise<void> => {
 		await eventPump;
 		dashboard.stopLiveUpdates();
 		tui.stop();
+		await stopPromise;
+		if (exitReason === "detached")
+			terminal.write(
+				`Detached; ${options.session.workflowName} is still running and may continue using tokens.\nStop it with: plot stop ${shellArgument(options.session.workflowPath)}\n`,
+			);
+		else if (exitReason === "stopped")
+			terminal.write(`Stopped ${options.session.workflowName}.\n`);
 	}
 };

--- a/packages/tui/test/dashboard.test.ts
+++ b/packages/tui/test/dashboard.test.ts
@@ -4,12 +4,16 @@ import { emptyProjection, type DashboardProjection } from "@plot/projection";
 
 const actions = () => {
 	const opened: string[] = [];
-	let quit = 0;
+	let stops = 0;
+	let detaches = 0;
 	let renders = 0;
 	return {
 		opened,
-		get quitCount() {
-			return quit;
+		get stopCount() {
+			return stops;
+		},
+		get detachCount() {
+			return detaches;
 		},
 		get renderCount() {
 			return renders;
@@ -18,8 +22,11 @@ const actions = () => {
 			tick: () => {},
 			refresh: () => {},
 			toggleDebug: () => {},
-			quit: () => {
-				quit++;
+			stop: () => {
+				stops++;
+			},
+			detach: () => {
+				detaches++;
 			},
 			openUrl: (url: string) => opened.push(url),
 			height: () => 24,
@@ -193,13 +200,33 @@ describe("PlotDashboard", () => {
 		).toContain("hello world again");
 	});
 
-	test("q exits and o opens selected work url", () => {
+	test("q confirms before stopping while d explicitly detaches", () => {
 		const a = actions();
 		const dashboard = new PlotDashboard(withWork(), a.actions);
 		dashboard.handleInput("o");
 		dashboard.handleInput("q");
+
 		expect(a.opened).toEqual(["https://example.com"]);
-		expect(a.quitCount).toBe(1);
+		expect(a.stopCount).toBe(0);
+		expect(dashboard.render(100).join("\n")).toContain("Stop workflow?");
+
+		dashboard.handleInput("q");
+		expect(a.stopCount).toBe(1);
+
+		const detached = actions();
+		new PlotDashboard(withWork(), detached.actions).handleInput("d");
+		expect(detached.detachCount).toBe(1);
+	});
+
+	test("escape cancels stop confirmation", () => {
+		const a = actions();
+		const dashboard = new PlotDashboard(withWork(), a.actions);
+		dashboard.handleInput("q");
+		dashboard.handleInput("\u001b");
+		dashboard.handleInput("q");
+
+		expect(a.stopCount).toBe(0);
+		expect(dashboard.render(100).join("\n")).toContain("Stop workflow?");
 	});
 
 	test("live render clock only runs while active", async () => {

--- a/packages/tui/test/fixtures/dashboard/backoff_queue.evidence.md
+++ b/packages/tui/test/fixtures/dashboard/backoff_queue.evidence.md
@@ -15,5 +15,5 @@
 │
 ├─ Activity
 │   nothing yet
-╰─ ↑↓ select   enter details   o open   t tick   c config   d debug   q quit
+╰─ ↑↓ select   enter details   o open   t tick   c config   b debug   d detach   q stop
 ```

--- a/packages/tui/test/fixtures/dashboard/backoff_queue.txt
+++ b/packages/tui/test/fixtures/dashboard/backoff_queue.txt
@@ -14,4 +14,4 @@
 │   ↻ retry in 2s · attempt 4                                                                                           
 │   ↻ wake in 10s · poll                                                                                                
 │                                                                                                                       
-╰─ ? help · q quit                                                                                                      
+╰─ ? help · d detach · q stop

--- a/packages/tui/test/fixtures/dashboard/idle.evidence.md
+++ b/packages/tui/test/fixtures/dashboard/idle.evidence.md
@@ -11,5 +11,5 @@
 │
 ├─ Activity
 │   nothing yet
-╰─ ↑↓ select   enter details   o open   t tick   c config   d debug   q quit
+╰─ ↑↓ select   enter details   o open   t tick   c config   b debug   d detach   q stop
 ```

--- a/packages/tui/test/fixtures/dashboard/idle.txt
+++ b/packages/tui/test/fixtures/dashboard/idle.txt
@@ -9,4 +9,4 @@
 │   no active work                                                                                                      
 │   ↻ wake in 26s · poll                                                                                                
 │                                                                                                                       
-╰─ ? help · q quit                                                                                                      
+╰─ ? help · d detach · q stop

--- a/packages/tui/test/fixtures/dashboard/super_busy.evidence.md
+++ b/packages/tui/test/fixtures/dashboard/super_busy.evidence.md
@@ -15,5 +15,5 @@
 │
 ├─ Activity
 │   nothing yet
-╰─ ↑↓ select   enter details   o open   t tick   c config   d debug   q quit
+╰─ ↑↓ select   enter details   o open   t tick   c config   b debug   d detach   q stop
 ```

--- a/packages/tui/test/fixtures/dashboard/super_busy.txt
+++ b/packages/tui/test/fixtures/dashboard/super_busy.txt
@@ -11,4 +11,4 @@
 │   ● #43 Item 43                                                                                          5s · 4.0k tok
 │     Posting review                                                                                                    
 │                                                                                                                       
-╰─ ? help · q quit                                                                                                      
+╰─ ? help · d detach · q stop

--- a/packages/tui/test/plot-tui.test.ts
+++ b/packages/tui/test/plot-tui.test.ts
@@ -9,7 +9,7 @@ const session: SessionSummary = {
 	id: "session-1",
 	workflowKey: "/repo/WORKFLOW.md",
 	workflowName: "review",
-	workflowPath: "/repo/WORKFLOW.md",
+	workflowPath: "/repo/WORK FLOW's.md",
 	projectPath: "/repo",
 	state: "online",
 	createdAt: "2026-01-01T00:00:00.000Z",
@@ -18,20 +18,17 @@ const session: SessionSummary = {
 	lastSequence: 0,
 };
 
-test("quitting the TUI detaches without stopping its Session", async () => {
+const harness = () => {
 	let stops = 0;
 	let eventStreamAborted = false;
 	const manager: SessionManagerRuntime = {
 		start: async () => ({ session, started: false }),
 		find: async () => session,
 		get: async () => session,
-		stop: async () => {
-			stops += 1;
-			return session;
-		},
+		stop: async () => session,
 		stopSession: async () => {
 			stops += 1;
-			return session;
+			return { ...session, state: "stopped" };
 		},
 		list: async () => [session],
 		events: (_id, _after, signal) => ({
@@ -64,16 +61,64 @@ test("quitting the TUI detaches without stopping its Session", async () => {
 	};
 	const input = new PassThrough();
 	const output = new PassThrough();
+	let text = "";
+	output.on("data", (chunk) => {
+		text += String(chunk);
+	});
 	const terminal = new ProcessTerminal(
 		input as unknown as NodeJS.ReadStream,
 		output as unknown as NodeJS.WriteStream,
 	);
+	return {
+		manager,
+		input,
+		terminal,
+		stops: () => stops,
+		output: () => text,
+		eventStreamAborted: () => eventStreamAborted,
+	};
+};
 
-	const running = runPlotTui({ manager, session, terminal });
+test("q and Ctrl-C confirm before stopping the Session", async () => {
+	for (const key of ["q", "\u0003"]) {
+		const state = harness();
+		const running = runPlotTui({
+			manager: state.manager,
+			session,
+			terminal: state.terminal,
+		});
+		// eslint-disable-next-line no-await-in-loop -- exercise both stop keys independently.
+		await Bun.sleep(1);
+		state.input.write(key);
+		// eslint-disable-next-line no-await-in-loop -- first key must leave the TUI open for confirmation.
+		await Bun.sleep(1);
+
+		expect(state.stops()).toBe(0);
+		state.input.write(key);
+		// eslint-disable-next-line no-await-in-loop -- each TUI must complete before creating the next.
+		await running;
+
+		expect(state.stops()).toBe(1);
+		expect(state.output()).toContain("Stopped review.");
+		expect(state.eventStreamAborted()).toBe(true);
+	}
+});
+
+test("d explicitly detaches and prints a copyable stop command", async () => {
+	const state = harness();
+	const running = runPlotTui({
+		manager: state.manager,
+		session,
+		terminal: state.terminal,
+	});
 	await Bun.sleep(1);
-	input.write("q");
+	state.input.write("d");
 	await running;
 
-	expect(stops).toBe(0);
-	expect(eventStreamAborted).toBe(true);
+	expect(state.stops()).toBe(0);
+	expect(state.output()).toContain(
+		"Detached; review is still running and may continue using tokens.",
+	);
+	expect(state.output()).toContain("plot stop '/repo/WORK FLOW'\\''s.md'");
+	expect(state.eventStreamAborted()).toBe(true);
 });


### PR DESCRIPTION
## Summary

- make `q` and Ctrl-C open a visible stop confirmation instead of silently detaching
- make `d` the explicit detach action and move debug view to `b`
- warn that detached Sessions may continue using tokens and print a shell-safe `plot stop` command
- wait for Session Manager shutdown and prevent detach/stop races while shutdown drains
- update TUI help, docs, package README, and behavioral tests

## Validation

- `bun run check`
- `bun run release:local --version 0.2.1 --skip-check`
- behavior tests cover `q`, Ctrl-C, explicit detach, stop confirmation cancellation, stream cleanup, and shell-safe stop commands
