### PR TITLE
fix(ipc): keep idle event streams alive

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -187,6 +187,8 @@ export const startPlotWebGateway = async (
 	const server = Bun.serve({
 		hostname: options.host ?? "127.0.0.1",
 		port: options.port ?? 0,
+		// SSE closes through request cancellation, not idle time.
+		idleTimeout: 0,
 		routes: {
 			"/api/health": {
 				GET: () => Response.json({ ok: true }),
@@ -219,11 +221,10 @@ export const startPlotWebGateway = async (
 					),
 			},
 			"/api/sessions/:sessionId/events": {
-				GET: (request, bun) => {
+				GET: (request) => {
 					const after = parseAfter(request);
 					if (after === undefined)
 						return errorResponse("invalid after sequence", 400);
-					bun.timeout(request, 0);
 					return withSession(manager, request.params.sessionId, () =>
 						eventsResponse({
 							request,

--- a/packages/session-manager/src/ipc.ts
+++ b/packages/session-manager/src/ipc.ts
@@ -267,8 +267,11 @@ export const startSessionManagerServer = async (input: {
 		assertRequestIdentity(request, input.options);
 		return work();
 	};
+	// Bun 1.3.5 honors this for Unix servers but omits it from the type.
+	// @ts-expect-error -- event continuations close through request cancellation.
 	const server = Bun.serve({
 		unix: socketPath,
+		idleTimeout: 0,
 		routes: {
 			"/health": {
 				GET: (request) => secured(request, () => Response.json({ ok: true })),
@@ -341,14 +344,13 @@ export const startSessionManagerServer = async (input: {
 					),
 			},
 			"/sessions/:sessionId/events": {
-				GET: (request, bun) =>
+				GET: (request) =>
 					secured(request, () => {
 						const after = Number(
 							new URL(request.url).searchParams.get("after") ?? 0,
 						);
 						if (!Number.isInteger(after) || after < 0)
 							throw new Error("after must be a non-negative integer");
-						bun.timeout(request, 0);
 						return eventStream(
 							request,
 							manager.events(request.params.sessionId, after, request.signal),

--- a/packages/session-manager/test/session-manager.test.ts
+++ b/packages/session-manager/test/session-manager.test.ts
@@ -473,7 +473,7 @@ test("stop still finds a Session after its Workflow alias disappears", async () 
 	);
 });
 
-test("an aborted IPC continuation releases an idle event stream", async () => {
+test("an idle IPC continuation survives Bun's default timeout and releases on abort", async () => {
 	const managerDir = await mkdtemp(join(tmpdir(), "plot-manager-ipc-"));
 	const sessions = manager();
 	const active = await sessions.start({
@@ -489,7 +489,15 @@ test("an aborted IPC continuation releases an idle event stream", async () => {
 	const events = client.events(active.session.id, 0, controller.signal);
 	const iterator = events[Symbol.asyncIterator]();
 	const next = iterator.next();
-	await Bun.sleep(1);
+	expect(
+		await Promise.race([
+			next.then(
+				() => "closed" as const,
+				() => "failed" as const,
+			),
+			Bun.sleep(12_250).then(() => "open" as const),
+		]),
+	).toBe("open");
 	controller.abort();
 	expect(
 		await Promise.race([
@@ -500,7 +508,7 @@ test("an aborted IPC continuation releases an idle event stream", async () => {
 	await server.close();
 	await sessions.shutdown();
 	await rm(managerDir, { recursive: true, force: true });
-});
+}, 15_000);
 
 test("unknown event streams preserve session_not_found through IPC", async () => {
 	const managerDir = await mkdtemp(join(tmpdir(), "plot-manager-events-"));


### PR DESCRIPTION
## Summary

Keep Session Manager NDJSON and Web SSE connections alive while Workflows are idle.

## Root cause

`Bun.serve` defaults to a 10-second server idle timeout. Plot attempted to disable that per request with `server.timeout(request, 0)`, but Bun 1.3.5 does not apply that override to these streaming responses. Idle TUI event continuations were reset with `ECONNRESET` after roughly 12 seconds.

## Changes

- disable idle timeout on the owning Session Manager Unix HTTP server
- disable idle timeout on the Web Gateway SSE server
- remove the ineffective route-level timeout calls
- prove a real IPC continuation remains open beyond Bun's default timeout and still releases on cancellation

## Verification

- [x] reproduced the exact failure against published `plot-ai@0.4.0`
- [x] `bun run check`
- [x] `bun run release:local --version 0.4.1-test --skip-check`
- [x] packaged `0.4.1-test` continuation remained open through 12.25 seconds of inactivity
